### PR TITLE
Feat: Swagger 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/moyo/backend/common/config/SwaggerConfig.java
+++ b/src/main/java/com/moyo/backend/common/config/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.moyo.backend.common.config;
+
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.moyo.backend.common.constant.MoyoConstants.BEARER;
+import static com.moyo.backend.common.constant.MoyoConstants.JWT;
+import static io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI moyoOpenAPI() {
+
+        return new OpenAPI()
+                .info(createInfo())
+                .components(new Components().addSecuritySchemes(JWT,createJwtConfig()));
+    }
+
+    private Info createInfo(){
+
+        return new Info()
+                .title("Moyo Server API")
+                .description("Moyo Server API 명세서")
+                .version("v1.0.0");
+    }
+    private SecurityScheme createJwtConfig(){
+
+        return new SecurityScheme()
+                .type(HTTP)
+                .scheme(BEARER)
+                .bearerFormat(JWT);
+    }
+}

--- a/src/main/java/com/moyo/backend/common/constant/MoyoConstants.java
+++ b/src/main/java/com/moyo/backend/common/constant/MoyoConstants.java
@@ -1,0 +1,8 @@
+package com.moyo.backend.common.constant;
+
+public class MoyoConstants {
+
+    public static final String JWT = "JWT";
+    public static final String BEARER = "Bearer";
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,0 @@
-spring.application.name=Moyo-Backend


### PR DESCRIPTION
close #1  

## ☑️ 완료 태스크
- [x] Swagger 환경설정
<br />

## 🔎 PR 내용

**2025.06.30** [API 문서화 개발로그](https://backend-newbie.tistory.com/37), 해당 방식으로 수정 했습니다. 더 이상 아래의 내용은 사용되지 않습니다.

<br/>

 Swagger OpenAPI를 이용하기 위한 환경설정 클래스를 추가했습니다.
<br />

## 🗣️논의하고 싶은점

Swagger 관련 세팅 정보들을 어노테이션으로 관리할지 직접 Info, SecurityScheme을 만들어서 관리할지 고민입니다. 또한 Swagger 설정에 관해서 수정하거나 추가할 부분이 있다면 논의해 보는게 좋을거 같습니다!

```java
@Configuration
@OpenAPIDefinition(
        info = @Info(
                title = "Moyo Server API",
                description = "Moyo Server API 명세서",
                version = "v1.0.0"
        )
)
@SecurityScheme(
        name = JWT,
        type = HTTP,
        scheme = BEARER,
        bearerFormat = JWT
)
public class SwaggerConfig {
}
``` 
PR 에서 구현한 방식과 위의 방식중 어느 것이 좋을지 의견 남겨 주면 좋을거 같아요! 저는 어노테이션 방식이 더 마음에 들었는데 추후 Swagger 관련해서 추가적인 설정들이 붙거나 변경 될 일이 있다면 어노테이션으로 관리하기에는 너무 난잡하지 않을까 싶어서 해당 방식을 선택하지 않았습니다. 또한 프로젝트 내에서 많이 사용될 JWT, Bearer 같은 문자열은 MoyoConstants에 상수로 만들었습니다.

<br />

## 📷 스크린샷


![image](https://github.com/user-attachments/assets/679ec9af-c36e-4d43-9b3a-28c32031badf)
![image](https://github.com/user-attachments/assets/167b0f43-3424-4d90-8b9a-719ac1596bdd)
![image](https://github.com/user-attachments/assets/803990b9-8e99-470f-ab5b-3ccc90a90c0d)

