### PR TITLE
Feat: BaseTimeEntity 추가

### DIFF
--- a/src/main/java/com/moyo/backend/MoyoBackendApplication.java
+++ b/src/main/java/com/moyo/backend/MoyoBackendApplication.java
@@ -2,7 +2,9 @@ package com.moyo.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MoyoBackendApplication {
 

--- a/src/main/java/com/moyo/backend/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/moyo/backend/domain/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.moyo.backend.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #5 

## ☑️ 완료 태스크
- [x] BaseTimeEntity 추가

<br />

## 🔎 PR 내용
 대부분의 엔티티의 변경 이력을 관리하기 위해서 공통 속성으로 생성일자, 수정일자가 필요합니다. 

 데이터의 생성일자와 수정일자를 기록하면 해당 데이터가 언제 생성되었고 언제 마지막으로 수정되었는지 추적할 수 있어서 데이터의 변경 이력을 추적하고 신뢰성을 유지하는 데 도움이 될 겁니다. 특히 우리 서비스의 특성상 주기적으로 데이터를 외부 API를 통해서 대규모 변경해야 하기 때문에 이를 관리하는 것은 필수라고 생각합니다.
 
 이를 위해서 엔티티 클래스가 상속 받을 수 있는 BaseTimeEntity를 구현 했습니다. 추후 필요하다면 누구에 의해서 데이터가 변경되었는지 관리하기 위한 BaseXXXEntity가 추가 될 수 있을거 같아요!

<br />

## 📷 스크린샷

![image](https://github.com/user-attachments/assets/33304175-0dfd-4235-a581-1de6bbddfa6c)

 JPA에서 사용될 @Entity가 붙은 엔티티 클래스들이 상속받아 사용가능하게 @MappedSuperclass를 선언 했습니다.

 해당 BaseTimeEntity는 직접 생성되지 않고 엔티티 클래스들의 공통 필드를 매핑하는 역할만을 담당합니다. 따라서 추상클래스로 정의했고 인스턴스를 생성 할 수 없게 만들었습니다.

 생성일자의 경우 최초로 값이 초기화 된 후 더 이상 수정할 수 없게 만들었습니다.

 데이터베이스의 트리거를 사용해서 데이터가 삽입되거나 변경될 때 마다 생성일자와 수정일자를 관리하는 방법도 있겠지만 Spring Data JPA를 사용한다면 데이터베이스 레벨에서 직접 설정하지 않아도 스프링 앱에서 코드레벨로 이를 관리 할 수 있어요!

 @EntityListeners(AuditingEntityListener.class)는 Spring Data JPA의 Auditing 기능을 사용하기 위한 코드 입니다. 해당 리스너를 통해 엔티티의 생성, 변경등의 이벤트 발생시 생성일, 수정일을 관리 할 수 있습니다. 

 이제 BaseEntity를 상속한 엔티티 클래스들은 생성일자와 수정일자 변경시 JPA Auditing을 통해서 이를 관리 할 수 있게 되고  


![image](https://github.com/user-attachments/assets/d3c748f6-00b7-4aa8-8ee4-e372b38aa251)
 메인 앱에서 @EnableJpaAuditing을 통해서 Auditing 기능을 활성화 시켜줄 수 있습니다. 다만 필요하다면 나중에 JpaConfig, JpaAuditingConfig를 따로 만들어서 이를 설정하는 것도 가능합니다. 아직 우리 프로젝트 구조에서 그럴 필요까지는 없어 보여서 main앱에 작성했습니다.


