### PR TITLE
Feat: API 공통 응답 포맷 추가

### DIFF
--- a/src/main/java/com/moyo/backend/common/constant/MoyoConstants.java
+++ b/src/main/java/com/moyo/backend/common/constant/MoyoConstants.java
@@ -5,4 +5,15 @@ public class MoyoConstants {
     public static final String JWT = "JWT";
     public static final String BEARER = "Bearer";
 
+    public static final int OK = 200;
+    public static final int NO_CONTENT = 204;
+    public static final int FOUND = 302;
+    public static final int BAD_REQUEST = 400;
+    public static final int UNAUTHORIZED = 401;
+    public static final int FORBIDDEN = 403;
+    public static final int NOT_FOUND = 404;
+    public static final int METHOD_NOT_ALLOWED = 405;
+    public static final int INTERNAL_SERVER_ERROR = 500;
+
+
 }

--- a/src/main/java/com/moyo/backend/common/model/ApiResponse.java
+++ b/src/main/java/com/moyo/backend/common/model/ApiResponse.java
@@ -1,0 +1,33 @@
+package com.moyo.backend.common.model;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.moyo.backend.common.constant.MoyoConstants.NO_CONTENT;
+import static com.moyo.backend.common.constant.MoyoConstants.OK;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"status", "code", "message", "data"})
+public class ApiResponse <T>{
+
+    private final int status;
+
+    private final String code;
+
+    private final String message;
+
+    private final T data;
+
+    public static <S> ApiResponse<S> success(S data){
+
+        return new ApiResponse<>(OK, "OK", null, data);
+    }
+
+    public static <S> ApiResponse<S> noContent(){
+
+        return new ApiResponse<>(NO_CONTENT, "NO_CONTENT", null, null);
+    }
+}


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #8 

## ☑️ 완료 태스크
- [x] API 공통 응답 구조 통일

<br />

## 🔎 PR 내용
 회의 결과에 맞게 API 공통 응답 구조를 통일했고 최종 Response DTO를 구현했어요!

<br />

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/61dd6e89-5d9f-4519-b8ff-e2eded2b4078)
![image](https://github.com/user-attachments/assets/8fcf45ff-eb1d-43e1-964f-5be7da7d22e2)

 우리 프로젝트에서 모든 응답은 위와 같이 통일하기로 회의에서 결정 했습니다. 이에 맞게 최종 응답 DTO를 구현했어요!

![image](https://github.com/user-attachments/assets/37f31d3a-f15f-4a15-b2d4-ad58f9121502)

 Json으로 직렬화시 필드의 직렬화 순서를 그대로 유지시키기 위해서 @JsonPropertyOerder를 선언했습니다.
 
 또한 최종 응답 DTO의 생성 전략은 사전에 @zzaekkii 백엔드 팀원끼리 약속한 대로 정적 팩토리 메서드만을 사용하기로 했습니다. 따라서 별도의 빌더는 만들지 않았고 정적 팩토리 메서드를 위한 생성자도 private로 선언 했습니다.


![image](https://github.com/user-attachments/assets/5e16790e-5c72-49ad-98b5-399fc904d12b)

 ApiResponse의 생성 메서드의 경우 크게 data가 존재하는 성공 응답과 data가 존재하지 않는 성공 응답으로 구분했습니다. 

 이 때, 메서드 네이밍은 success, noContent로 기존의 정적 팩토리 메서드 관례를 따르지는 않았습니다. 관례를 따르면 ofSuccess(), ofNoContent()가 되어야 할거 같은데 이는 가독성을 해치지 않을까 생각했고 사전에 모든 팀원들끼리 협의한 대로 메서드 네이밍을 간단하게 선택했습니다.

 또한 ApiResponse<T> 제네릭 타입과 success(), noContent()같은 제네릭 메서드는 현재 한 클래스 안에서 정의 되었지만 이는 서로의 타입 매개변수에 영향을 주지 않습니다.

 
![image](https://github.com/user-attachments/assets/0cb287d3-b46b-4448-9420-b3e18684c176)
 예를 들어 이런식으로 타입 매개변수를 동일하게 T로 설정한다고 해서  제네릭 타입과 제네릭 메서드가 서로 영향을 주지 않습니다. 
 
 따라서 가독성을 위해서 타입 매개변수는 T, S, U ... 등으로 여러개를 사용했습니다.

![image](https://github.com/user-attachments/assets/b193fdf9-258a-4684-9653-5b7fb9f46c43)
 또한 HTTP 상태 코드는 직접 MoyoConstant에 정의했습니다. 스프링에서 기존에 제공하는 Enum인 HttpStatus를 사용해도 됩니다.

![image](https://github.com/user-attachments/assets/288ef933-257c-444d-890c-c414d61a6c5d)
 하지만 이런 방식으로 사용하는 것보다는 
![image](https://github.com/user-attachments/assets/6363b36c-3178-4c69-955f-b49b95052af9)
직접 상수를 정의하는게 더 가독성이 좋아보여서 직접 상수를 선언했습니다.


 응답 성공 시 우리 서버에서 커스텀으로 만드는 code의 경우 실제로 클라이언트에서 사용될 일이 없을거 같습니다. 따라서 모든 응답 성공에 대한 커스텀 코드는 "OK", "No Content"와 같이 통일해서 응답할 생각입니다.

 마지막으로 아직 예외 처리 전략에 대해서 구체적인 논의가 되지 않은 상황이라서 API 응답 실패 상황에 대한 최종 응답 DTO는 별도로 만들지 않았습니다!