### PR TITLE
Feat: 공통 예외 처리 Response 추가

### DIFF
--- a/src/main/java/com/moyo/backend/common/constant/MoyoConstants.java
+++ b/src/main/java/com/moyo/backend/common/constant/MoyoConstants.java
@@ -13,7 +13,7 @@ public class MoyoConstants {
     public static final int FORBIDDEN = 403;
     public static final int NOT_FOUND = 404;
     public static final int METHOD_NOT_ALLOWED = 405;
-    public static final int INTERNAL_SERVER_ERROR = 500;
+    public static final int SERVER_ERROR = 500;
 
 
 }

--- a/src/main/java/com/moyo/backend/common/exception/BaseErrorCode.java
+++ b/src/main/java/com/moyo/backend/common/exception/BaseErrorCode.java
@@ -1,0 +1,6 @@
+package com.moyo.backend.common.exception;
+
+public interface BaseErrorCode {
+
+    ErrorReason getErrorReason();
+}

--- a/src/main/java/com/moyo/backend/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/moyo/backend/common/exception/CommonErrorCode.java
@@ -1,10 +1,11 @@
 package com.moyo.backend.common.exception;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import static com.moyo.backend.common.constant.MoyoConstants.SERVER_ERROR;
 
-
+@Getter
 @RequiredArgsConstructor
 public enum CommonErrorCode implements BaseErrorCode{
 

--- a/src/main/java/com/moyo/backend/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/moyo/backend/common/exception/CommonErrorCode.java
@@ -1,0 +1,23 @@
+package com.moyo.backend.common.exception;
+
+import lombok.RequiredArgsConstructor;
+
+import static com.moyo.backend.common.constant.MoyoConstants.SERVER_ERROR;
+
+
+@RequiredArgsConstructor
+public enum CommonErrorCode implements BaseErrorCode{
+
+    // 예시
+    UNKNOWN_INTERNAL_SERVER_ERROR(SERVER_ERROR, "COMMON_500_1", "서버 내부에서 알수 없는 에러가 발생 했습니다. 관리자에게 문의해 주세요.")
+    ;
+
+    private final Integer status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return new ErrorReason(status,code,message);
+    }
+}

--- a/src/main/java/com/moyo/backend/common/exception/ErrorReason.java
+++ b/src/main/java/com/moyo/backend/common/exception/ErrorReason.java
@@ -1,0 +1,12 @@
+package com.moyo.backend.common.exception;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+public class ErrorReason {
+
+    private Integer status;
+    private String code;
+    private String errorMessage;
+}

--- a/src/main/java/com/moyo/backend/common/exception/MoyoException.java
+++ b/src/main/java/com/moyo/backend/common/exception/MoyoException.java
@@ -1,0 +1,15 @@
+package com.moyo.backend.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MoyoException extends RuntimeException{
+
+    private final BaseErrorCode baseErrorCode;
+
+    public ErrorReason getErrorReason(){
+        return baseErrorCode.getErrorReason();
+    }
+}

--- a/src/main/java/com/moyo/backend/common/model/ApiResponse.java
+++ b/src/main/java/com/moyo/backend/common/model/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.moyo.backend.common.model;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.moyo.backend.common.exception.ErrorReason;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,5 +30,10 @@ public class ApiResponse <T>{
     public static <S> ApiResponse<S> noContent(){
 
         return new ApiResponse<>(NO_CONTENT, "NO_CONTENT", null, null);
+    }
+
+    public static <S> ApiResponse<S> fail(ErrorReason errorReason){
+
+        return new ApiResponse<>(errorReason.getStatus(), errorReason.getCode(), errorReason.getErrorMessage(), null);
     }
 }


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #22 

## ☑️ 완료 태스크
- [x] 공통 예외 처리 Response 추가

<br />

## 🔎 PR 내용
 예외처리 응답을 통일하기 위한 작업들을 진행 했어요!

<br />

## 1️⃣ 공통 응답 구조 

![image](https://github.com/user-attachments/assets/a369664a-3e93-44b8-ae4f-eb549ed04302)
우리 프로젝트에서 처리할 커스텀 예외들은 언체크 예외를 상속받는 MoyoException으로 통일합니다. 우리 서비스에서 발생하는 대부분의 예외는 체크 예외로 만들어 줄 필요는 없습니다. 예외가 발생해도 당장에 처리할 수 있는 게 없고 예외가 발생한 곳에서 쭉 올려서 GlobalExceptionHandler (ControllerAdvice) 에서 모아서 처리하게 합니다. 
<br /><br />

![image](https://github.com/user-attachments/assets/63e8db77-c3ac-46f5-98f4-438956aa7b9e)
이런식으로 우리가 필요한 에러들을 만들 때 MoyoException을 상속받게 만들 수 있습니다. 만약 매번 커스텀 예외를 만들 때 마다 각각의  예외가 RuntimeException을 상속받게 하면 GlobalExceptionHandler에서 이를 처리하기 굉장히 곤란해 집니다.

매번 GlobalExceptionHandler에서 각각의 커스텀 예외들을 잡아서 처리하게 만들거나 이런 번거로운 작업이 싫으면 RuntimeException 자체를 잡아서 처리하도록 만들어야 하는데 RuntimeException에는 우리가 커스텀 하지 않은 모든 언체크 예외가 포함되어 버립니다. 따라서 RuntimeException을 상속받는 MoyoException이 필요합니다.
<br /><br />

![image](https://github.com/user-attachments/assets/d66b260e-f4e2-4a5b-a5dc-a146b5064afd)
회의의 결과대로 모든 예외는 위와 같이 통일해서 응답하기로 했습니다. 따라서 우리 프로젝트에서 에러 발생시 data를 제외한 HTTP status code, Error Custom Code, Explain Message가 공통적으로 필요합니다. 
<br /><br />

![image](https://github.com/user-attachments/assets/4977d4b6-079b-4ad6-8e8d-9451af1a29da)
이를 위해 MoyoException을 상속받을 커스텀 예외들의 내부에는 status, code, message가 매번 필요한데 이는 각각의 커스텀 예외마다 모두 공통필드인데 내용만 다르니 이를 관리하기 위해서 ErrorCode라는 Enum을 만들어서 관리하면 좋습니다.
<br /><br />

![image](https://github.com/user-attachments/assets/74e0b84c-df1f-4ef6-9670-9c1e1bfa35d0)
예를 들어 위와 같이 Enum으로 ErrorCode들을 관리할 수 있습니다. 하지만 위의 예시에서 보면 알 수 있듯이 ErrorCode가 너무 중구난방 합니다. 인증에 관련된 에러코드, 각기 다른 도메인에 관련된 에러코드 등이 모두 한 곳에서 모여서 관리됩니다. 이는 추후 프로젝트 규모가 커짐에 따라서 굉장히 불편해 질 수 있습니다. 각기 다른 도메인 마다 XXXErrorCode, OOOErrorCode와 같이 에러를 분리해서 처리하면 좋을거 같습니다.
<br /><br />

![image](https://github.com/user-attachments/assets/5eae36b3-0aae-4860-9622-bc20c68fa11f)
따라서 모든 Enum에 공통적으로 있는 status, code, message를 추출해서 운반할 DTO를 하나 만들어 준 다음
<br />
![image](https://github.com/user-attachments/assets/870d3c98-2086-4828-8ff3-01e320750fcf)
모든 XXXErrorCode Enum들이 구현해야할 BaseErrorCode라는 인터페이스를 하나 만들었습니다.
<br /><br />

![image](https://github.com/user-attachments/assets/9d092868-d2ff-47a0-9505-434153d802ae)
예를 들어 어느 도메인에도 속하지 않는 공통 커스텀 예외들을 묶어놓은 CommonErrorCode라는 것을 만들어서 BaseErrorCode를 구현하게 하면 ErrorReason DTO를 통해서 각각의 예외의 status, code, message를 전달 받을 수 있습니다. 이를 사용해서 예외를 실제로 처리하는 것은 다른 이슈에서 구현하겠습니다!
<br /><br />


## 🧾 ref (반드시 읽어 보세요)
[두둥 예외처리 예시 블로그] (https://devnm.tistory.com/27)