### PR TITLE
Feat: 예외처리를 위한 GlobalExceptionHandler 추가

### DIFF
--- a/src/main/java/com/moyo/backend/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/moyo/backend/common/exception/CommonErrorCode.java
@@ -3,13 +3,17 @@ package com.moyo.backend.common.exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import static com.moyo.backend.common.constant.MoyoConstants.SERVER_ERROR;
+import static com.moyo.backend.common.constant.MoyoConstants.*;
 
 @Getter
 @RequiredArgsConstructor
 public enum CommonErrorCode implements BaseErrorCode{
 
     // 예시
+    INVALID_PARAM(BAD_REQUEST, "COMMON_400_1", "파라미터를 다시 확인해 주세요."),
+    PARAM_TYPE_MISMATCH(BAD_REQUEST, "COMMON_400_2", "파라미터의 타입을 다시 확인해 주세요."),
+    RESOURCE_NOT_FOUND(NOT_FOUND, "COMMON_404_1", "리소스를 찾을 수 없습니다."),
+    NOT_ALLOWED_METHOD(METHOD_NOT_ALLOWED, "COMMON_405_1", "허용되지 않은 메서드 입니다."),
     UNKNOWN_INTERNAL_SERVER_ERROR(SERVER_ERROR, "COMMON_500_1", "서버 내부에서 알수 없는 에러가 발생 했습니다. 관리자에게 문의해 주세요.")
     ;
 
@@ -18,7 +22,7 @@ public enum CommonErrorCode implements BaseErrorCode{
     private final String message;
 
     @Override
-    public ErrorReason getErrorReason() {
+        public ErrorReason getErrorReason() {
         return new ErrorReason(status,code,message);
     }
 }

--- a/src/main/java/com/moyo/backend/common/exception/ErrorReason.java
+++ b/src/main/java/com/moyo/backend/common/exception/ErrorReason.java
@@ -6,7 +6,12 @@ import lombok.*;
 @AllArgsConstructor
 public class ErrorReason {
 
-    private Integer status;
-    private String code;
+    private final Integer status;
+    private final String code;
     private String errorMessage;
+
+    public void addDetailErrorMessage(String detailMessage){
+
+        errorMessage += detailMessage;
+    }
 }

--- a/src/main/java/com/moyo/backend/common/exception/ExampleException.java
+++ b/src/main/java/com/moyo/backend/common/exception/ExampleException.java
@@ -1,0 +1,9 @@
+package com.moyo.backend.common.exception;
+
+public class ExampleException extends MoyoException{
+
+    public static final MoyoException EXCEPTION = new ExampleException();
+    private ExampleException() {
+        super(CommonErrorCode.UNKNOWN_INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/moyo/backend/common/exception/ExampleException.java
+++ b/src/main/java/com/moyo/backend/common/exception/ExampleException.java
@@ -1,9 +1,0 @@
-package com.moyo.backend.common.exception;
-
-public class ExampleException extends MoyoException{
-
-    public static final MoyoException EXCEPTION = new ExampleException();
-    private ExampleException() {
-        super(CommonErrorCode.UNKNOWN_INTERNAL_SERVER_ERROR);
-    }
-}

--- a/src/main/java/com/moyo/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moyo/backend/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,112 @@
+package com.moyo.backend.common.exception;
+
+import com.moyo.backend.common.model.ApiResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    // Custom Exception
+    @ExceptionHandler(MoyoException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMoyoException(MoyoException ex){
+
+        ErrorReason errorReason = ex.getErrorReason();
+
+        return ResponseEntity.status(errorReason.getStatus()).body(ApiResponse.fail(errorReason));
+    }
+
+    // @Valid
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        String detailErrorMessage = ex.getBindingResult().getAllErrors().stream()
+                .map(ObjectError::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+        detailErrorMessage += ".";
+
+        ErrorReason errorReason = CommonErrorCode.INVALID_PARAM.getErrorReason();
+        errorReason.addDetailErrorMessage(detailErrorMessage);
+
+        return ResponseEntity.status(errorReason.getStatus()).body(ApiResponse.fail(errorReason));
+    }
+
+    // @Validated
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidated(ConstraintViolationException ex){
+
+        String detailErrorMessage = ex.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.joining(" , "));
+        detailErrorMessage += ".";
+
+        ErrorReason errorReason = CommonErrorCode.INVALID_PARAM.getErrorReason();
+        errorReason.addDetailErrorMessage(detailErrorMessage);
+
+        return ResponseEntity.status(errorReason.getStatus()).body(ApiResponse.fail(errorReason));
+    }
+
+    // Type MisMatch
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex) {
+
+        ErrorReason errorReason = CommonErrorCode.PARAM_TYPE_MISMATCH.getErrorReason();
+
+        return ResponseEntity.status(errorReason.getStatus()).body(ApiResponse.fail(errorReason));
+    }
+
+    // 404
+    @Override
+    protected ResponseEntity<Object> handleNoResourceFoundException(NoResourceFoundException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        ErrorReason errorReason = CommonErrorCode.RESOURCE_NOT_FOUND.getErrorReason();
+
+        return ResponseEntity.status(status).body(ApiResponse.fail(errorReason));
+    }
+
+    // 405
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        ErrorReason errorReason = CommonErrorCode.NOT_ALLOWED_METHOD.getErrorReason();
+
+        return ResponseEntity.status(errorReason.getStatus()).body(ApiResponse.fail(errorReason));
+    }
+
+    // Delegate to ResponseEntityExceptionHandler
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+        ErrorReason errorReason = new ErrorReason(statusCode.value(), "COMMON_"+statusCode.value() ,ex.getMessage());
+
+        return ResponseEntity.status(statusCode).body(ApiResponse.fail(errorReason));
+    }
+
+    // 500
+    @ExceptionHandler(Exception.class)
+    private ResponseEntity<ApiResponse<Void>> handleUnknownInternalException(Exception e){
+
+        ErrorReason errorReason = CommonErrorCode.UNKNOWN_INTERNAL_SERVER_ERROR.getErrorReason();
+
+        log.error("Unknown Internal Server Error  : ", e);
+
+        return ResponseEntity.status(errorReason.getStatus()).body(ApiResponse.fail(errorReason));
+    }
+}

--- a/src/main/java/com/moyo/backend/common/exception/MoyoException.java
+++ b/src/main/java/com/moyo/backend/common/exception/MoyoException.java
@@ -7,9 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MoyoException extends RuntimeException{
 
-    private final BaseErrorCode baseErrorCode;
+    private final BaseErrorCode errorCode;
 
     public ErrorReason getErrorReason(){
-        return baseErrorCode.getErrorReason();
+        return errorCode.getErrorReason();
     }
 }

--- a/src/main/java/com/moyo/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/moyo/backend/security/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/reissue/token", "/health", "/","/permit/all/test").permitAll()
+                .requestMatchers("/auth/reissue/token", "/health", "/","/permit/all/test", "/error/**").permitAll()
                 .anyRequest().authenticated()
         );
 


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #25 

## ☑️ 완료 태스크
- [x] GlobalExceptionHandler 구현
- [x] 클라이언트의 요청에 대한 검증 예외처리 구현 

<br />

## 🔎 PR 내용
 #24 이전 PR에서 공통 예외 응답 구조를 만들었었고 이번 PR에서는 해당 예외들을 처리할 공통 핸들러를 추가했어요!

<br />

## 1️⃣ ResponseEntityExceptionHandler를 이용해서 COMMON ERROR 처리

<br/>

![image](https://github.com/user-attachments/assets/737b6926-f921-4eb7-87a4-67f17b1e87d9)
ResponseEntityExceptionHandler의 공식 문서를 살펴보면 해당 클래스는 스프링 MVC에서 발생할 수 있는 대부분의 예외들을 처리 할 수 있는 메서드를 갖고 있다고 나와 있습니다.

해당 클래스를 상속받는 GlobalExceptionHandler를 구현하게 되면 굉장히 개발 생산성을 높일 수 있을거 같습니다.  

<br/>

![image](https://github.com/user-attachments/assets/c3b5b37c-4c45-4feb-8fbd-77cd920da929)
ResponseEntityExceptionHandler 내부에는 이렇게 대부분의 예외를 미리 처리하고 있습니다.

<br/>

예를 들어 어떤 API에 대해서 405 Method Not Allowed 예외를 의도적으로 발생시키면 

![image](https://github.com/user-attachments/assets/273c61ef-d41c-4e5e-a6c1-e53d844ede6f)
해당 예외가 발생하게 되고

![image](https://github.com/user-attachments/assets/189c61f0-cffd-474d-9542-6fb1a2b4a134)
ResponseEntityExceptionHandler 내부의 handleException()이 호출 됩니다.

![image](https://github.com/user-attachments/assets/3cec19cc-6fad-445f-83e4-f4a83ebbfbaa)
 이는 해당 상황에서 특정 예외를 처리하는 handleHttpRequestMethodNotSupported()를 호출하게 되고 해당 메서드는 HttpRequestMethodNotSupportedException이 발생했을 때 처리해야할 예외처리 로직을 거친 후 다시 handleExceptionInternal() 을 호출합니다.

![image](https://github.com/user-attachments/assets/e6376772-b9fd-47c4-abe9-8e02aa3874bb)

handleExceptionInternal()의 경우 ResponseEntityExceptionHandler 에서 어떤 예외가 발생하더라도 반드시 최종적으로 호출됩니다. 해당 메서드는 모든 예외들이 공통적으로 처리해줘야 할 로직을 실행 시키고 마지막으로createResponseEntity()를 호출해 줍니다.

![image](https://github.com/user-attachments/assets/471050bb-5a0e-487b-8c90-d559729f93b9)
최종적으로는 이런 응답을 만들어 줍니다.

<br/>
여기서 ResponseEntityExceptionHandler의 각각의 메서드의 내부 구현 과정 보다는 각각 메서드가 수행하는 역할이 무엇인지에 주목해서 우리의 입맛에 맞게 커스터마이징 할 수 있습니다.

![image](https://github.com/user-attachments/assets/c38b9d01-7ab4-432a-9e14-9027f1578188)
 
예를 들어서 handleHttpRequestMethodNotSupported()를 오버라이딩 하게 되면 Method Not Allowed 관련 예외가 발생 했을 때 이에 대한 처리 과정을 직접 구현 할 수 있습니다. 다른 메서드들도 마찬가지로 커스터마이징 하고 싶은 예외가 있다면 오버라이딩 해버리면 됩니다.

![image](https://github.com/user-attachments/assets/0d45ad5f-a62b-40d5-96dd-8a31cf048dcb)
또한 ResponseEntityExceptionHandler에 어떤 예외를 처리해 달라고 위임하게 되면 특정 예외를 처리하면서 반드시 공통적으로 호출되는 handleExceptionInternal()을 커스터마이징 하게 되면 ResponseEntityExceptionHandler가 처리하는 모든 예외들의 공통적인 부분을 커스터 마이징 할 수 있습니다.


<br/>

![image](https://github.com/user-attachments/assets/ad3332b8-ba9f-4798-b702-dbe042b19a6a)

우리 프로젝트에는 어떤 예외가 발생하더라도 반드시 위와 같은 예외응답 구조로 통일해 달라는 요구 사항이 있었습니다. ResponseEntityExceptionHandler가 기본적으로 제공하는 응답 구조와 우리 프로젝트에서 필요로 하는 응답구조는 다르기 때문에 이를 
 handleExceptionInternal()을 커스터 마이징 해서 구현했습니다.


<br/>

1. 지금까지의 내용을 정리하자면 GlobalExceptionHandler를 구현함.
2. ResponseEntityExceptionHandler를 이용하면 스프링 MVC를 사용하면서 발생할 수 있는 대부분의 예외를 컨트롤 할 수 있음.
3. 자주 발생하는 404, 405 등등의 예외는 ResponseEntityExceptionHandler의 해당 예외를 처리하는 메서드를 오버라이딩해서 직접 커스터 마이징함.
4. 나머지 예외들은 ResponseEntityExceptionHandler에게 위임해서 처리하는 대신 우리 프로젝트의 공통 응답구조 통일을 위해서 handleExceptionInternal()을 커스터 마이징 함.

<br/>

## 2️⃣ 커스텀 예외 처리
![image](https://github.com/user-attachments/assets/7404a4ec-f627-407e-add3-cc0af85555d4)

 우리 프로젝트에서 발생할 수 있는 런타임 예외들은 MoyoException을 상속받게 만들었고 이에 대한 처리를 담당할 부분입니다. 
<br/>

![image](https://github.com/user-attachments/assets/a750fbf8-a5db-4426-92dc-55ce632a038d)
MoyoException의 경우 내부에 BaseErrorCode 인터페이스를 가지고 있습니다.
<br/>

![image](https://github.com/user-attachments/assets/265580a3-ee72-4c25-80df-2ec52648f6f7)
모든 {Domain}ErrorCode들은 이에 대한 구현체 입니다.
<br/>

![image](https://github.com/user-attachments/assets/8c3ecdbd-f7a3-42fd-9393-a119ef81f10c)
![image](https://github.com/user-attachments/assets/7a70f7e6-2a48-4a86-a559-c50af4236d47)
모든 BaseErrorCode의 구현체들은 ErrorReason DTO를 반환하는 메서드를 구현해야 합니다.

이 때, ErrorReason의 경우 클라이언트가 서버에 전달한 값 검증 시 공통 Enum으로 관리하는 Error Explain Message에 추가적으로 어떤 파라미터에서 문제가 발생했는지 알려주기로 회의 때 결정했습니다. 

이를 위해서 message 필드는 detailMessage를 추가 할 수 있게 했습니다. 이에 대한건 아래에서 자세히 설명 하겠습니다.
<br/>

## 3️⃣ Validation 예외 처리
 해당 부분에 대해서 이번에 새로 알게 된 내용이 너무 많아서 틀린 부분이 있을 수 있습니다.

 우선 클라이언트에게 JSON 형태의 데이터를 전달 받고 이를 @RequestBody를 사용해서 받습니다. 이 경우 int age 에 "SS" 같은 값이 들어가게 되면 MethodArgumentTypeMismatchException가 발생합니다.
<br/>

![image](https://github.com/user-attachments/assets/02d3a11d-cd7d-4a56-9c57-39979bd42336)
이는 위와같이 ResponseEntityExceptionHandler의 타입 미스매치 처리 메서드를 커스터 마이징 했습니다.

<br/>

 이제 실제로 ReqeustDTO의 각각의 값을 검증하기 위해서는 Controller에서 RequestDTO의 필드를 검증하는 로직이 필요합니다. 이는 스프링이 제공하는 Validator 인터페이스를 구현하고 구현체를 등록 한 다음, @Validted를 통해서 쉽게 사용할 수 있습니다.

 하지만 대부분의 검증로직의 경우 Bean Validation을 사용하면 더 쉽게 검증 가능합니다. 최대값, 이메일등등의 기본적인 검증기는 이미 모두 만들어져 있고 이를 위해 Bean Validation을 사용하면 됩니다.

 이를 위해 `'org.springframework.boot:spring-boot-starter-validation'` 의존성을 추가해 줘야 합니다. Bean Validation의 경우 검증 애노테이션 모음 표준 인터페이스 라고 이해 하면 됩니다.

![image](https://github.com/user-attachments/assets/19ae03e8-8421-4a61-b370-9f4671849cf4)
아마 위의 라이브러리가 기본적인 구현체 인걸로 추측이 됩니다. 보통 jakarta.validation 으로 시작합니다.
<br/>

![image](https://github.com/user-attachments/assets/6897a60b-e966-4d22-8302-134054972500)
`
'org.springframework.boot:spring-boot-starter-validation'` 이를 당겨오게 되면 빈 밸리데이션의 구현체인 하이버네이트 검증기가 추가 되는데 아마 기본적으로 제공되는 jakarta.validation 보다 더 많은 내용을 담고 있는 것으로 보입니다. 

<br/>

![image](https://github.com/user-attachments/assets/1a7229c4-0152-4fce-9613-1f03f44e4b1b)
예를 들어 어떤 범위를 검증하는 @Range의 경우 하이버네이트 검증기에만 있는거 같아요. 추측성 내용입니다.

이런식으로 Bean Validation의 구현체들을 이용해서 손쉽게 별도의 검증 로직을 만들지 않고 각각의 필드에 대한 검증을 진행 할 수 있어요. 내부적인 검증기 세팅은 스프링 부트의 자동 환경설정을 이용하는 거 같습니다.

데이터 검증 시 @Valid와 @Validated의 차이는 @Validated는 스프링에서 제공하는 @Valid만으로 안되는 여러가지 기능을 확장시키기 위한 어노테이션 이라는 점인데, @Valid의 경우 MethodArgumentNotValidException을, Validated의 경우 ConstraintViolationException을 발생 시킵니다. (정확하지 않을 수 있음)

따라서 해당 예외들은 모두 커스터 마이징 해뒀습니다.





## ref

[ResponseEntityExceptionHandler 공식 문서](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/mvc/method/annotation/ResponseEntityExceptionHandler.html)

[ResponseEntityExceptionHandler G마켓 기술블로그](https://dev.gmarket.com/83)

[스프링 MVC2 -인프런 김영한](https://www.inflearn.com/course/%EC%8A%A4%ED%94%84%EB%A7%81-mvc-2?srsltid=AfmBOopSoVjI9bShKRuxBdEMevPRIXQy-Wgg-fACIwCsbLxmrTxuRu0X)