### PR TITLE
Fix: JWT Provider, 예외 핸들러 코드 에러 수정

### DIFF
--- a/src/main/java/com/moyo/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moyo/backend/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.moyo.backend.common.model.ApiResponse;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -64,10 +64,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     // Type MisMatch
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex) {
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
         ErrorReason errorReason = CommonErrorCode.PARAM_TYPE_MISMATCH.getErrorReason();
+
+        String detailErrorMessage = "요구 타입: " + ex.getRequiredType().getName() + ", 입력 값: " + ex.getValue();
+        errorReason.addDetailErrorMessage(detailErrorMessage);
 
         return ResponseEntity.status(errorReason.getStatus()).body(ApiResponse.fail(errorReason));
     }

--- a/src/main/java/com/moyo/backend/security/jwt/util/JwtProvider.java
+++ b/src/main/java/com/moyo/backend/security/jwt/util/JwtProvider.java
@@ -1,7 +1,6 @@
 package com.moyo.backend.security.jwt.util;
 
 
-import com.moyo.backend.domain.user.Role;
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -30,7 +29,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .claim(TOKEN_TYPE, ACCESS_TYPE)
                 .claim(PROVIDER_ID, providerId)
-                .claim(ROLE, Role.USER)
+                .claim(ROLE, role)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + JWT_ACCESS_EXPIRES_MS))
                 .signWith(secretKey)


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #28 

## ☑️ 완료 태스크
- [x] JWT ACCESS 발급 에러 수정
- [x] TypeMismatch 핸들 에러 수정

<br />

## 🔎 PR 내용

 로그인, 에러 핸들 과정에서 발생한 예외를 수정했습니다.

## 1️⃣ JWT ACCESS 발급 에러 수정

JWT ACCESS 발급 시 토큰의 ROLE 클레임에 무조건 ROLE.USER를 넣고 있는 걸 발견 했어요.

ROLE 클레임에는 해당 유저의 실제 DB에 저장된 ROLE 값이 들어가야 하기에 이를 수정했습니다!
<br/>

##  2️⃣ TypeMismatch 핸들 에러 수정 

ResponseEntityExceptionHandler 에서는 타입 미스매치 예외를 TypeMismatchException 예외를 처리하는 handleTypeMismatch()로 처리하고 있는데 실수로 해당 메서드를 커스터마이징 하지 않고 따로 타입 미스 매치 예외를 잡아서 처리하고 있는 걸 발견 했고 이를 수정했어요! 