### PR TITLE
Refactor: 테스트 서버 로그인 요구사항 변경

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Moyo API Test Server Deploy
 on:
   push:
     branches:
-      - test
+      - develop
     path: backend/**
 
 jobs:

--- a/src/main/java/com/moyo/backend/common/constant/MoyoConstants.java
+++ b/src/main/java/com/moyo/backend/common/constant/MoyoConstants.java
@@ -5,6 +5,8 @@ public class MoyoConstants {
     public static final String BEARER = "Bearer";
     public static final String SET_COOKIE = "Set-Cookie";
     public static final String AUTHORIZATION = "Authorization";
+
+    public static final String JSON = "application/json";
     public static final String GITHUB_REGISTRATION_ID = "github";
     public static final String ANONYMOUS_USER = "anonymousUser";
 

--- a/src/main/java/com/moyo/backend/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/moyo/backend/common/security/config/SecurityConfig.java
@@ -1,10 +1,12 @@
-package com.moyo.backend.security.config;
+package com.moyo.backend.common.security.config;
 
-import com.moyo.backend.security.jwt.filter.JWTAuthenticationFilter;
-import com.moyo.backend.security.jwt.util.JwtPayloadReader;
-import com.moyo.backend.security.jwt.util.JwtValidator;
-import com.moyo.backend.security.oauth.handler.OAuthLoginSuccessHandler;
-import com.moyo.backend.security.oauth.service.GithubOAuth2UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moyo.backend.common.security.jwt.filter.JWTAuthenticationExceptionHandleFilter;
+import com.moyo.backend.common.security.jwt.filter.JWTAuthenticationFilter;
+import com.moyo.backend.common.security.jwt.util.JwtPayloadReader;
+import com.moyo.backend.common.security.jwt.util.JwtValidator;
+import com.moyo.backend.common.security.oauth.handler.OAuthLoginSuccessHandler;
+import com.moyo.backend.common.security.oauth.service.GithubOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +24,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final ObjectMapper objectMapper;
     private final GithubOAuth2UserService userService;
     private final OAuthLoginSuccessHandler loginSuccessHandler;
     private final JwtPayloadReader jwtPayloadReader;
@@ -46,7 +49,8 @@ public class SecurityConfig {
         );
 
         http
-                .addFilterAfter(new JWTAuthenticationFilter(jwtValidator,jwtPayloadReader), OAuth2LoginAuthenticationFilter.class);
+                .addFilterAfter(new JWTAuthenticationFilter(jwtValidator,jwtPayloadReader), OAuth2LoginAuthenticationFilter.class)
+                .addFilterBefore(new JWTAuthenticationExceptionHandleFilter(objectMapper), JWTAuthenticationFilter.class);
 
         http
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/moyo/backend/common/security/jwt/controller/JwtReissueController.java
+++ b/src/main/java/com/moyo/backend/common/security/jwt/controller/JwtReissueController.java
@@ -1,8 +1,8 @@
-package com.moyo.backend.security.jwt.controller;
+package com.moyo.backend.common.security.jwt.controller;
 
 
+import com.moyo.backend.common.security.jwt.service.JwtReissueService;
 import com.moyo.backend.common.util.CookieFactory;
-import com.moyo.backend.security.jwt.service.JwtReissueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;

--- a/src/main/java/com/moyo/backend/common/security/jwt/exception/LoginErrorCode.java
+++ b/src/main/java/com/moyo/backend/common/security/jwt/exception/LoginErrorCode.java
@@ -1,0 +1,26 @@
+package com.moyo.backend.common.security.jwt.exception;
+
+import com.moyo.backend.common.exception.BaseErrorCode;
+import com.moyo.backend.common.exception.ErrorReason;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static com.moyo.backend.common.constant.MoyoConstants.UNAUTHORIZED;
+
+@Getter
+@RequiredArgsConstructor
+public enum LoginErrorCode implements BaseErrorCode {
+    
+    // 임시
+    JWT_EXPIRED(UNAUTHORIZED, "LOGIN_401_1", "JWT 만료")
+    ;
+
+    private final Integer status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return new ErrorReason(status,code,message);
+    }
+}

--- a/src/main/java/com/moyo/backend/common/security/jwt/filter/JWTAuthenticationExceptionHandleFilter.java
+++ b/src/main/java/com/moyo/backend/common/security/jwt/filter/JWTAuthenticationExceptionHandleFilter.java
@@ -1,0 +1,49 @@
+package com.moyo.backend.common.security.jwt.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moyo.backend.common.exception.ErrorReason;
+import com.moyo.backend.common.model.ApiResponse;
+import com.moyo.backend.common.security.jwt.exception.LoginErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.moyo.backend.common.constant.MoyoConstants.JSON;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JWTAuthenticationExceptionHandleFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        // 임시
+        try{
+            filterChain.doFilter(request,response);
+        }
+        catch (ExpiredJwtException ex){
+
+            createErrorResponse(response,LoginErrorCode.JWT_EXPIRED.getErrorReason());
+        }
+    }
+
+    private void createErrorResponse(HttpServletResponse httpServletResponse, ErrorReason errorReason) throws IOException {
+
+        httpServletResponse.setStatus(errorReason.getStatus());
+        httpServletResponse.setContentType(JSON);
+        httpServletResponse.setCharacterEncoding("UTF-8");
+
+        String jsonResponse = objectMapper.writeValueAsString(ApiResponse.fail(errorReason));
+        httpServletResponse.getWriter().write(jsonResponse);
+    }
+}
+

--- a/src/main/java/com/moyo/backend/common/security/jwt/filter/JWTAuthenticationFilter.java
+++ b/src/main/java/com/moyo/backend/common/security/jwt/filter/JWTAuthenticationFilter.java
@@ -1,10 +1,10 @@
-package com.moyo.backend.security.jwt.filter;
+package com.moyo.backend.common.security.jwt.filter;
 
+import com.moyo.backend.common.security.jwt.util.JwtValidator;
 import com.moyo.backend.domain.user.Role;
-import com.moyo.backend.security.jwt.util.JwtPayloadReader;
-import com.moyo.backend.security.jwt.util.JwtValidator;
-import com.moyo.backend.security.oauth.dto.GitHubOAuth2User;
-import com.moyo.backend.security.oauth.dto.UserDto;
+import com.moyo.backend.common.security.jwt.util.JwtPayloadReader;
+import com.moyo.backend.common.security.oauth.dto.GitHubOAuth2User;
+import com.moyo.backend.common.security.oauth.dto.UserDto;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/moyo/backend/common/security/jwt/service/JwtReissueService.java
+++ b/src/main/java/com/moyo/backend/common/security/jwt/service/JwtReissueService.java
@@ -1,9 +1,9 @@
-package com.moyo.backend.security.jwt.service;
+package com.moyo.backend.common.security.jwt.service;
 
-import com.moyo.backend.security.jwt.util.JwtPayloadReader;
-import com.moyo.backend.security.jwt.util.JwtProvider;
-import com.moyo.backend.security.jwt.util.JwtValidator;
-import com.moyo.backend.security.oauth.repository.LoginRepository;
+import com.moyo.backend.common.security.jwt.util.JwtPayloadReader;
+import com.moyo.backend.common.security.jwt.util.JwtProvider;
+import com.moyo.backend.common.security.jwt.util.JwtValidator;
+import com.moyo.backend.common.security.oauth.repository.LoginRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/moyo/backend/common/security/jwt/util/JwtPayloadReader.java
+++ b/src/main/java/com/moyo/backend/common/security/jwt/util/JwtPayloadReader.java
@@ -1,4 +1,4 @@
-package com.moyo.backend.security.jwt.util;
+package com.moyo.backend.common.security.jwt.util;
 
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/moyo/backend/common/security/jwt/util/JwtProvider.java
+++ b/src/main/java/com/moyo/backend/common/security/jwt/util/JwtProvider.java
@@ -1,4 +1,4 @@
-package com.moyo.backend.security.jwt.util;
+package com.moyo.backend.common.security.jwt.util;
 
 
 import io.jsonwebtoken.Jwts;
@@ -23,6 +23,16 @@ public class JwtProvider {
 
     public JwtProvider(@Value("${spring.jwt.secret}") String jwtSecret) {
         this.secretKey = new SecretKeySpec(jwtSecret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    // Reissue Trigger JWT Access
+    public String createExpiredJwtAccess(){
+        return Jwts.builder()
+                .claim(TOKEN_TYPE, ACCESS_TYPE)
+                .issuedAt(new Date(System.currentTimeMillis() - 60000))
+                .expiration(new Date(System.currentTimeMillis() - 30000))
+                .signWith(secretKey)
+                .compact();
     }
 
     public String createJwtAccess(String providerId, String role) {

--- a/src/main/java/com/moyo/backend/common/security/jwt/util/JwtValidator.java
+++ b/src/main/java/com/moyo/backend/common/security/jwt/util/JwtValidator.java
@@ -1,4 +1,4 @@
-package com.moyo.backend.security.jwt.util;
+package com.moyo.backend.common.security.jwt.util;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -36,7 +36,9 @@ public class JwtValidator {
             isAccessToken(token);
 
         } catch (ExpiredJwtException e){   // ExpiredJwtException -> ClaimJwtException -> JwtException
-            throw new RuntimeException("JWT Access 만료 예외 발생");
+
+            log.warn("JWT Access Expired");
+            throw e;
         } catch (JwtException | IllegalArgumentException e) {
             throw new RuntimeException("유효하지 않은 JWT 예외 발생");
         }

--- a/src/main/java/com/moyo/backend/common/security/oauth/dto/GitHubOAuth2User.java
+++ b/src/main/java/com/moyo/backend/common/security/oauth/dto/GitHubOAuth2User.java
@@ -1,4 +1,4 @@
-package com.moyo.backend.security.oauth.dto;
+package com.moyo.backend.common.security.oauth.dto;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/moyo/backend/common/security/oauth/dto/GithubUserProfile.java
+++ b/src/main/java/com/moyo/backend/common/security/oauth/dto/GithubUserProfile.java
@@ -1,4 +1,4 @@
-package com.moyo.backend.security.oauth.dto;
+package com.moyo.backend.common.security.oauth.dto;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/moyo/backend/common/security/oauth/dto/UserDto.java
+++ b/src/main/java/com/moyo/backend/common/security/oauth/dto/UserDto.java
@@ -1,8 +1,7 @@
-package com.moyo.backend.security.oauth.dto;
+package com.moyo.backend.common.security.oauth.dto;
 
 import com.moyo.backend.domain.user.Role;
 import com.moyo.backend.domain.user.User;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/moyo/backend/common/security/oauth/handler/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/moyo/backend/common/security/oauth/handler/OAuthLoginSuccessHandler.java
@@ -1,10 +1,10 @@
-package com.moyo.backend.security.oauth.handler;
+package com.moyo.backend.common.security.oauth.handler;
 
+import com.moyo.backend.common.security.jwt.util.JwtPayloadReader;
+import com.moyo.backend.common.security.jwt.util.JwtProvider;
+import com.moyo.backend.common.security.oauth.dto.GitHubOAuth2User;
+import com.moyo.backend.common.security.oauth.repository.LoginRepository;
 import com.moyo.backend.common.util.CookieFactory;
-import com.moyo.backend.security.jwt.util.JwtPayloadReader;
-import com.moyo.backend.security.jwt.util.JwtProvider;
-import com.moyo.backend.security.oauth.dto.GitHubOAuth2User;
-import com.moyo.backend.security.oauth.repository.LoginRepository;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -40,7 +40,6 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         this.frontLoginSuccessURI = frontLoginSuccessURI;
     }
 
-
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
 
@@ -51,9 +50,12 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         String role = String.valueOf(gitHubOAuth2User.getAuthorities().stream().findFirst().orElseThrow(RuntimeException::new));
 
         String jwtRefresh = jwtProvider.createJwtRefresh(providerId,role);
+        String expiredJwtAccess = jwtProvider.createExpiredJwtAccess();
+
         loginRepository.save(providerId, jwtRefresh, jwtPayloadReader.getExpiration(jwtRefresh));
 
         response.addHeader(SET_COOKIE, cookieFactory.createJwtRefreshCookie(jwtRefresh).toString());
+        response.addHeader(SET_COOKIE, cookieFactory.createExpiredAccessTokenCookie(expiredJwtAccess).toString());
         response.sendRedirect(frontLoginSuccessURI);
     }
 }

--- a/src/main/java/com/moyo/backend/common/security/oauth/repository/LoginRepository.java
+++ b/src/main/java/com/moyo/backend/common/security/oauth/repository/LoginRepository.java
@@ -1,4 +1,4 @@
-package com.moyo.backend.security.oauth.repository;
+package com.moyo.backend.common.security.oauth.repository;
 
 import java.util.Date;
 

--- a/src/main/java/com/moyo/backend/common/security/oauth/repository/LoginRepositoryImpl.java
+++ b/src/main/java/com/moyo/backend/common/security/oauth/repository/LoginRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.moyo.backend.security.oauth.repository;
+package com.moyo.backend.common.security.oauth.repository;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.Cursor;

--- a/src/main/java/com/moyo/backend/common/security/oauth/service/GithubOAuth2UserService.java
+++ b/src/main/java/com/moyo/backend/common/security/oauth/service/GithubOAuth2UserService.java
@@ -1,10 +1,10 @@
-package com.moyo.backend.security.oauth.service;
+package com.moyo.backend.common.security.oauth.service;
 
+import com.moyo.backend.common.security.oauth.dto.GitHubOAuth2User;
+import com.moyo.backend.common.security.oauth.dto.GithubUserProfile;
 import com.moyo.backend.domain.user.User;
 import com.moyo.backend.domain.user.UserRepository;
-import com.moyo.backend.security.oauth.dto.GitHubOAuth2User;
-import com.moyo.backend.security.oauth.dto.GithubUserProfile;
-import com.moyo.backend.security.oauth.dto.UserDto;
+import com.moyo.backend.common.security.oauth.dto.UserDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;

--- a/src/main/java/com/moyo/backend/common/util/CookieFactory.java
+++ b/src/main/java/com/moyo/backend/common/util/CookieFactory.java
@@ -18,10 +18,10 @@ public class CookieFactory {
     public ResponseCookie createJwtRefreshCookie(String jwtRefresh) {
         return ResponseCookie.from(REFRESH_TYPE, jwtRefresh)
                 .path("/")
-                .maxAge(300)
+                .maxAge(6000)
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("Lax")
+                .sameSite("None")
                 .domain(domain)
                 .build();
     }

--- a/src/main/java/com/moyo/backend/common/util/CookieFactory.java
+++ b/src/main/java/com/moyo/backend/common/util/CookieFactory.java
@@ -4,15 +4,19 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
+import static com.moyo.backend.common.constant.MoyoConstants.ACCESS_TYPE;
 import static com.moyo.backend.common.constant.MoyoConstants.REFRESH_TYPE;
 
 @Component
 public class CookieFactory {
 
     private final String domain;
+    private final String samesite;
 
-    public CookieFactory(@Value("${spring.cookie.domain}") String domain) {
+    public CookieFactory(@Value("${spring.cookie.domain}") String domain,
+                         @Value("${spring.cookie.samesite}") String samesite) {
         this.domain = domain;
+        this.samesite = samesite;
     }
 
     public ResponseCookie createJwtRefreshCookie(String jwtRefresh) {
@@ -21,8 +25,20 @@ public class CookieFactory {
                 .maxAge(6000)
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("None")
+                .sameSite(samesite)
                 .domain(domain)
                 .build();
     }
+
+    // Reissue Trigger Access Token Cookie (HTTP Only false)
+    public ResponseCookie createExpiredAccessTokenCookie(String jwtAccess) {
+        return ResponseCookie.from(ACCESS_TYPE, jwtAccess)
+                .path("/")
+                .httpOnly(false)
+                .secure(true)
+                .sameSite(samesite)
+                .maxAge(600)
+                .build();
+    }
+
 }

--- a/src/main/java/com/moyo/backend/domain/common/AuthTestController.java
+++ b/src/main/java/com/moyo/backend/domain/common/AuthTestController.java
@@ -1,6 +1,6 @@
 package com.moyo.backend.domain.common;
 
-import com.moyo.backend.security.oauth.dto.GitHubOAuth2User;
+import com.moyo.backend.common.security.oauth.dto.GitHubOAuth2User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/moyo/backend/domain/user/User.java
+++ b/src/main/java/com/moyo/backend/domain/user/User.java
@@ -1,6 +1,6 @@
 package com.moyo.backend.domain.user;
 
-import com.moyo.backend.security.oauth.dto.GithubUserProfile;
+import com.moyo.backend.common.security.oauth.dto.GithubUserProfile;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/moyo/backend/security/jwt/util/JwtProvider.java
+++ b/src/main/java/com/moyo/backend/security/jwt/util/JwtProvider.java
@@ -15,8 +15,8 @@ import static com.moyo.backend.common.constant.MoyoConstants.*;
 @Component
 public class JwtProvider {
 
-    private static final long JWT_ACCESS_EXPIRES_MS = 1000 * 60;
-    private static final long JWT_REFRESH_EXPIRES_MS = 1000 * 60 * 5;
+    private static final long JWT_ACCESS_EXPIRES_MS = 1000 * 60 *10;
+    private static final long JWT_REFRESH_EXPIRES_MS = 1000 * 60 * 100;
 
 
     private final SecretKey secretKey;

--- a/src/main/java/com/moyo/backend/security/oauth/handler/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/moyo/backend/security/oauth/handler/OAuthLoginSuccessHandler.java
@@ -8,8 +8,8 @@ import com.moyo.backend.security.oauth.repository.LoginRepository;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -20,13 +20,26 @@ import static com.moyo.backend.common.constant.MoyoConstants.SET_COOKIE;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtProvider jwtProvider;
     private final JwtPayloadReader jwtPayloadReader;
     private final LoginRepository loginRepository;
     private final CookieFactory cookieFactory;
+    private final String frontLoginSuccessURI;
+
+    public OAuthLoginSuccessHandler(JwtProvider jwtProvider,
+                                    JwtPayloadReader jwtPayloadReader,
+                                    LoginRepository loginRepository,
+                                    CookieFactory cookieFactory,
+                                    @Value("${spring.login.default-uri}") String frontLoginSuccessURI) {
+        this.jwtProvider = jwtProvider;
+        this.jwtPayloadReader = jwtPayloadReader;
+        this.loginRepository = loginRepository;
+        this.cookieFactory = cookieFactory;
+        this.frontLoginSuccessURI = frontLoginSuccessURI;
+    }
+
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -41,6 +54,6 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         loginRepository.save(providerId, jwtRefresh, jwtPayloadReader.getExpiration(jwtRefresh));
 
         response.addHeader(SET_COOKIE, cookieFactory.createJwtRefreshCookie(jwtRefresh).toString());
-        response.sendRedirect("http://localhost:3000/test");
+        response.sendRedirect(frontLoginSuccessURI);
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,7 +3,7 @@ spring:
   # JPA
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
 # Log
 logging:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -3,7 +3,7 @@ spring:
   # JPA
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
 # Log
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
 
   # CORS Allow Origin
   cors:
-    allow-origin: ${ALLOW_ORIGIN:http://localhost:3000}
+    allow-origin: ${ALLOW_ORIGIN:http://localhost:5173}
 
   # Login
   cookie:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,8 @@ spring:
   # Login
   cookie:
     domain: ${COOKIE_DOMAIN:localhost}
+    samesite: ${COOKIE_SAME_SITE:Strict}
+
   login:
     default-uri: ${DEFAULT_URI:http://localhost:5173/menu}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,9 +21,11 @@ spring:
   cors:
     allow-origin: ${ALLOW_ORIGIN:http://localhost:3000}
 
-  # Cookie Domain
+  # Login
   cookie:
     domain: ${COOKIE_DOMAIN:localhost}
+  login:
+    default-uri: ${DEFAULT_URI:http://localhost:5173/menu}
 
   # Security
   security:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,10 +21,10 @@ spring:
   cors:
     allow-origin: ${ALLOW_ORIGIN:http://localhost:5173}
 
-  # Login
+  # Cookie
   cookie:
-    domain: ${COOKIE_DOMAIN:localhost}
-    samesite: ${COOKIE_SAME_SITE:Strict}
+    domain: ${COOKIE_DOMAIN}
+    samesite: ${COOKIE_SAME_SITE}
 
   login:
     default-uri: ${DEFAULT_URI:http://localhost:5173/menu}


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #35 

## ☑️ 완료 태스크
- [x] 앱 실행 환경에 따른 로그인 분리 작업

<br />

## 🔎 PR 내용
local 개발 환경, test 서버 배포 환경, prod 서버 배포 환경에서 앱 실행시 각 환경에 맞는 환경변수를 설정만 하면 로그인을 진행 할 수 있게 로그인 로직을 리팩토링 했어요! 이번 PR에서 가장 중요하게 생각한 것은 일부 변경된 로그인 로직을 반영하고 환경변수 설정 만으로 각각의 개발환경에 맞는 로그인 로직을 만드는 것이었습니다.
<br />

## 1️⃣ Cors Allow Origin 설정

![image](https://github.com/user-attachments/assets/1f04e97c-ed29-47d3-b85b-9064fe8f70b6)

우선 Cors Allow Origin 설정의 기본 값을 변경 했습니다. 배포된 api 테스트 서버는 localhost:5173에서 테스트 할 수 있게 해달라는 요청이 있었습니다! 따라서 별도의 환경 세팅이 없다면 해당 Origin으로 Cors Allow Origin이 설정 됩니다.

간단한 리액트를 이용해서 로컬환경에서 테스트 해보고 싶다면 localhost:3000으로, 운영서버에 배포해야 한다면 프론트 배포 도메인으로, 테스트 서버라면 아무 값도 넣지 않으면 됩니다.

아마 서로 다른 도메인 간 쿠키를 주고 받는 요청을 테스트해야 하기 때문에 로그인에 성공해도 쿠키를 받을 수는 없을 겁니다. 추후 프론트에서 localhost에 https를 적용하게 되면서 무조건 변경 되겠지만 서현님이 일단은 지금과 같은 환경에서 다른 방법이 있을지 테스트 해보고 싶다고 하셔서 위와 같이 설정 했어요!

1. [local 테스트] cors allow origin = http://localhost:3000
2. [테스트 서버] cors allow origin = http://localhost:5173 (http로는 불가능해서 테스트 후 변경될거임)
3. [운영 서버] cors allow origin = 프론트 Origin
<br/>

## 2️⃣ Cookie Domain, Samesite 설정

![image](https://github.com/user-attachments/assets/4bfe8461-1d63-44d8-8f7f-487d53354cd0)

환경변수로 쿠키의 Domain과 Samesite 설정을 추가했습니다.

이 부분은 제가 알고 있는 지식이 정확하지 않을 수 있습니다! 계속 새로 알게 되는 내용이 있다면 수정 할게요!

![image](https://github.com/user-attachments/assets/79232ca6-614b-4859-b965-13cb1623c3e3)

이는 RFC 6265 공식 문서입니다! 쿠키에 Domain이라는 값을 설정하면 doamin 속성에 대해서 설정할 수 있다는 설명입니다.

해당 속성은 쿠키에 접근 (read, update, delete, 전송 등등)가능한 도메인을 지정하는 속성입니다. 쿠키로 전달할 Refresh Token의 경우 XSS공격 방지를 위해서 HTTP Only 설정을 주기 떄문에 JS로 read, update, delete는 애초에 불가능 합니다. 

웹 브라우저의 쿠키 저장소에 쿠키가 저장되게 하고 리프레시 토큰 재발급 요청에 쿠키 저장소에 있는 리프레시 토큰이 서버로 다시 전송되는 것 까지가 우리가 신경 쓸 부분이에요.

이를 테스트 서버 환경과 운영 서버 환경에서 각 각 다른 요구사항을 갖고 있어서 따로 살펴봐야 합니다.

테스트 서버의 경우 (프론트 : localhost, 백엔드 : api.test.com) 같은 환경에서 동작합니다. 서로 도메인이 다르죠.
운영서버의 경우 (프론트: www.prod.com, 백엔드 : api.prod.com) 환경에서 동작합니다. 도메인은 다르지만 둘 다 prod.com의 서브 도메인입니다.

운영서버의 경우 도메인이 같은 환경에서 쿠키를 전달하기 때문에 상대적으로 쿠키 전달이 쉽습니다.

만약 도메인 설정을 하지 않으면 쿠키의 도메인은 쿠키 발급자인 api.prod.com으로 설정되고 www.prod.com 같은 서브 도메인에서는 쿠키를 읽거나 전송하는게 불가능 합니다.

api.prod.com에서 쿠키를 만들어서 Set-Cookie 헤더를 통해서 응답을 넘길 때 쿠키의 domain에 .prod.com을 설정해 준다면 프론트쪽 서브 도메인인 www.prod.com에서도 쿠키가 유효하게 사용가능해 집니다.

또한 프론트에서 백에 다시 이 쿠키를 전달하는 요청을 날리더라도 웹 브라우저에서 .prod.com을 확인하고 api.prod.com은 유효한 도메인이니 쿠키를 잘 전송해 줄 수 있겠다 라고 판단합니다.

하지만 문제는 테스트 환경은 도메인 자체가 localhost, prod.com으로 완전히 다르기 때문에 이런 방식을 사용할 수 없어요.

만약 doamin을 localhost로 설정하게 된다면 api.prod.com에서 발급한 쿠키는 프론트에서 유효하긴 하지만 서버로 재전송 해야할 때 쿠키의 도메인인 localhost와 api.prod.com이 일치하지 않으니 차단됩니다. 반대로 domain을 .prod.com으로 설정하면 아마 쿠키를 전달 받을 수 조차 없지 않을까 생각 돼요. (정확하지는 않아요)

이런 문제를 해결하기 위해서 쿠키의 samesite 속성을 사용할 수 있습니다. samesite 옵션은 쿠키를 이용한 csrf 공격을 방어하기 위한 속성인데 크케 stict, lax, none이 있습니다. csrf 공격은 우리 서비스에서 로그인 후 쿠키에 리프레시 토큰을 발급 받은 사용자가 새 창을 띄우고 웹 서핑을 하다가 우연히 우리 서비스에 대한 악의적인 요청을 숨겨놓은 사이트에 방문하면서 발생합니다.

우리는 인증용 토큰을 쿠키에 저장하지는 않기 때문에 리프레시 토큰을 사용자가 의도하지 않게 재발급 하는 요청 이나 리프레시 토큰 탈취용 공격을 당할수 있지 않을까 생각이 드네요.

이렇게 우리는 리프레시 토큰을 쿠키에 저장하고 Http Only를 주기 떄문에 xss 공격은 방어가 가능하지만 csrf 공격에는 취약합니다. 이를 방지하기 위해서 쿠키가 제공하는 samesite = lax, strict를 통해서 csrf 방어가 가능해요. 

strict의 경우 사용자가 우리 사이트 외부에서 요청을 보내는 경우에 절대로 해당 쿠키는 전송되지 않는 옵션입니다. lax는 이보다는 느슨한 방식인데 우리 사이트 외부에서 요청을 보낼때 특정 조건을 만족해야만 해당 쿠키를 함께 전송하는 옵션입니다.

그럼 csrf공격을 방지하기 위해서 strict를 쓸까 lax를 쓸까 고민인데 제 생각에는 외부에서 우리 서비스를 이용하기 위해서 요청이 발생할 일이 없지 않나?라는 생각이 듭니다. 따라서 절대 허용하지 않도록 strict를 적용해 보는게 좋을거 같아요. 물론 운영서버에 이를 적용하는 건 좀 깊게 생각을 해봐야 할거 같아요!

그럼 운영서버는 domain설정과 samesite설정이 해결 되었고 이제 다시 테스트 서버가 문제 입니다. 테스트 서버의 경우 우리가 의도적으로 서로 다른 도메인에서 쿠키 전송을 허용해 줘야하기 때문에 samesite = none을 이용해야 해요. 

이 때 samesite 가 None이면 반드시 Secure 설정을 해줘야 합니다. 즉 https가 적용되어 있지 않으면 사용할 수 없는 속성입니다.

결론은 테스트 서버에서는 samesite=none, domain은 .test.com이 되어야 합니다. 이 의미는 해당 쿠키는 .test.com의 하위 도메인에서 사용되는 쿠키이며 Cross site 간에도 쿠키 전송이 허용된다는 의미에요.

1. [local 테스트] domain=localhost, samesite=Lax or Strict
2. [테스트 서버] domain=테스트 서버 도메인, samesite = None
3. [운영 서버] domain=.운영서버 도메인, samesite = Lax or Strict (추후 협의)

<br/>

## 3️⃣ 로그인 성공 후 리다이렉트 URL 설정

![image](https://github.com/user-attachments/assets/07826c2a-9b53-4e6a-95f1-6773ef86b38f)

현재 OAuth 로그인의 모든 부분을 백에서 처리하기 때문에 리다이렉트 없이 토큰을 전달하는게 불가능 합니다. 프론트에서 원하는 리다이렉트 URL을 주면 해당 경로로 리다이렉트 시킬거고 만약 아무것도 주지 않으면 default 경로로 리다이렉트 시킵니다.

1. [local 테스트] DEFAULT_URI = http://localhost:3000/test
2. [테스트 서버] DEFAULT_URI = http://localhost:5173/menu (변경 될거임 http 이슈)
3. [운영 서버] DEFAULT_URI = https://프론트 도메인 + 기본 경로 (추후 결정)
<br/>

## 4️⃣ 로그인 로직 변경 사항

![image](https://github.com/user-attachments/assets/c6551768-2e7f-4a19-920a-979db19c4e1a)

로그인 방식이 회의를 거쳐서 위와 같이 변경 되었습니다. 로그인 후 Refresh 토큰을 쿠키로 전달 받은 것 까지는 좋은데 Access를 발급 받기 위해서 다시 Access 재발급 요청을 날리는 로직을 프론트에서 추가로 만들어 줘야 하는 상황이었습니다.

그렇다고 Access Token을 null로 설정해 주게 되면 최초 로그인 한 사용자가 우연히 모두에게 허용되어 있지만 인증된 사용자에게 추가 리소스를 제공하는 API를 요청할 경우 비인증 사용자로 식별해 버린다는 문제가 있었습니다. 추가로 자잘한 엣지 케이스들이 더 있었는데 자세한건 회의록에 기록 되어 있습니다.

결론은 HTTP Only 설정이 안 붙은 가짜 리이슈 트리거용 Access Token을 함께 쿠키로 전송하는 것이었어요. 해당 액세스 토큰은 토큰타입을 제외한 어떤 정보도 기록되어 있지 않고 발급 할 때 부터 이미 만료되어 있습니다. 즉 털리더라도 Base 64로 디코딩 해봐야 아무 정보도 들어있지 않고 애초에 만료된 토큰이기 떄문에 사용할 수도 없습니다.

따라서 최초 로그인 시 리프레시 토큰은 정상적으로 전달하고 쿠키에 JS로 접근가능한 리이슈 트리거용 Access 토큰을 함께 전달하기로 했고 로그인을 성공한 사용자가 해당 토큰을 서버에 전송하면 Access Token 만료 에러 핸들링을 통해 토큰 재발급 요청을 할 수 있게 했습니다.

## ref

[쿠키 관련 RFC 공식문서](https://www.rfc-editor.org/rfc/rfc6265#section-5.3)

[쿠키 관련 정리글](https://ko.javascript.info/cookie)

[쿠키 관련 MDN 문서](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)
