### PR TITLE
Refactor: JWT 재발급 응답 구조 수정

### DIFF
--- a/src/main/java/com/moyo/backend/common/util/CookieFactory.java
+++ b/src/main/java/com/moyo/backend/common/util/CookieFactory.java
@@ -30,15 +30,4 @@ public class CookieFactory {
                 .build();
     }
 
-    // Reissue Trigger Access Token Cookie (HTTP Only false)
-    public ResponseCookie createExpiredAccessTokenCookie(String jwtAccess) {
-        return ResponseCookie.from(ACCESS_TYPE, jwtAccess)
-                .path("/")
-                .httpOnly(false)
-                .secure(true)
-                .sameSite(samesite)
-                .maxAge(600)
-                .build();
-    }
-
 }

--- a/src/main/java/com/moyo/backend/security/jwt/controller/JwtReissueController.java
+++ b/src/main/java/com/moyo/backend/security/jwt/controller/JwtReissueController.java
@@ -1,6 +1,7 @@
 package com.moyo.backend.security.jwt.controller;
 
 
+import com.moyo.backend.common.model.ApiResponse;
 import com.moyo.backend.security.jwt.service.JwtReissueService;
 import com.moyo.backend.common.util.CookieFactory;
 import lombok.RequiredArgsConstructor;
@@ -21,13 +22,12 @@ public class JwtReissueController {
     private final CookieFactory cookieFactory;
 
     @PostMapping("/auth/reissue/token")
-    public ResponseEntity<Void> reissueJwtTokens(@CookieValue("refresh") String jwtRefreshToken){
+    public ResponseEntity<ApiResponse<?>> reissueJwtTokens(@CookieValue("refresh") String jwtRefreshToken){
 
         Map<String, String> reIssueTokens = jwtReissueService.reIssueJwt(jwtRefreshToken);
 
         return ResponseEntity.status(OK)
-                .header(AUTHORIZATION, BEARER + " " + reIssueTokens.get(ACCESS_TYPE))
                 .header(SET_COOKIE, cookieFactory.createJwtRefreshCookie(reIssueTokens.get(REFRESH_TYPE)).toString())
-                .build();
+                .body(ApiResponse.success(new JwtReissueResponse(reIssueTokens.get(ACCESS_TYPE))));
     }
 }

--- a/src/main/java/com/moyo/backend/security/jwt/controller/JwtReissueResponse.java
+++ b/src/main/java/com/moyo/backend/security/jwt/controller/JwtReissueResponse.java
@@ -1,0 +1,11 @@
+package com.moyo.backend.security.jwt.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtReissueResponse {
+
+    private String accessToken;
+}

--- a/src/main/java/com/moyo/backend/security/oauth/handler/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/moyo/backend/security/oauth/handler/OAuthLoginSuccessHandler.java
@@ -51,13 +51,10 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         log.info("Id : {} 회원 로그인 성공 후 JWT 발급 시작", userId);
 
         String jwtRefresh = jwtProvider.createJwtRefresh(userId,role);
-        String expiredJwtAccess = jwtProvider.createExpiredJwtAccess();
 
         loginRepository.save(userId, jwtRefresh, jwtPayloadReader.getExpiration(jwtRefresh));
 
         response.addHeader(SET_COOKIE, cookieFactory.createJwtRefreshCookie(jwtRefresh).toString());
-        response.addHeader(SET_COOKIE, cookieFactory.createExpiredAccessTokenCookie(expiredJwtAccess).toString());
         response.sendRedirect(frontLoginSuccessURI);
-
     }
 }


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #47 

## ☑️ 완료 태스크
- [x] JWT 재발급 시 ATK를 헤더에서 바디로 이동
- [x] 최초 로그인시 트리거용 ATK 삭제

<br />

## 🔎 PR 내용

서현님과 회의에서 로그인 방식에 대해 논의 했던 대로 최초 로그인시 RTK를 통한 ATK 재발급을 위한 트리거용 ATK를 삭제 했어요! 자세한 내용은 디스코드 "로그인 구현 방식 관련 논의" 쓰레드에 남아있습니다!

또한 프론트에서 응답 헤더에 재발급 된 ATK를 심어주는 것 보다는 바디에 주는게 더 접근성이 좋다고 하셔서 ATK를 바디로 이동했습니다!

코드 품질이나 테스트 코드는 로그인 관련쪽 전체 리팩토링 때 한번에 수정해 볼게요!