### PR TITLE
Refactor: 팔로우 탐지기에 Redis 캐시 추가

### DIFF
--- a/src/main/java/com/moyo/backend/common/config/RedisConfig.java
+++ b/src/main/java/com/moyo/backend/common/config/RedisConfig.java
@@ -1,13 +1,19 @@
 package com.moyo.backend.common.config;
 
+import com.moyo.backend.githubfollow.model.FollowUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import static org.springframework.data.redis.serializer.StringRedisSerializer.UTF_8;
 
 @Configuration
 @RequiredArgsConstructor
@@ -22,12 +28,23 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+
+        StringRedisTemplate redisTemplate = new StringRedisTemplate();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        redisTemplate.setDefaultSerializer(UTF_8);
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, FollowUser> followUserRedisTemplate() {
+        RedisTemplate<String, FollowUser> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setDefaultSerializer(UTF_8);
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return redisTemplate;
     }

--- a/src/main/java/com/moyo/backend/common/config/RedisConfig.java
+++ b/src/main/java/com/moyo/backend/common/config/RedisConfig.java
@@ -10,10 +10,8 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import static org.springframework.data.redis.serializer.StringRedisSerializer.UTF_8;
 
 @Configuration
 @RequiredArgsConstructor
@@ -22,9 +20,8 @@ public class RedisConfig {
     private final RedisProperties redisProperties;
 
     @Bean
-    public LettuceConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(redisProperties.host, redisProperties.port);
-        return new LettuceConnectionFactory(configuration);
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisProperties.host, redisProperties.port));
     }
 
     @Bean
@@ -33,18 +30,17 @@ public class RedisConfig {
         StringRedisTemplate redisTemplate = new StringRedisTemplate();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
 
-        redisTemplate.setDefaultSerializer(UTF_8);
         return redisTemplate;
     }
 
     @Bean
     public RedisTemplate<String, FollowUser> followUserRedisTemplate() {
+
         RedisTemplate<String, FollowUser> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
-        redisTemplate.setDefaultSerializer(UTF_8);
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(FollowUser.class));
 
         return redisTemplate;
     }

--- a/src/main/java/com/moyo/backend/common/constant/MoyoConstants.java
+++ b/src/main/java/com/moyo/backend/common/constant/MoyoConstants.java
@@ -17,7 +17,7 @@ public class MoyoConstants {
     public static final String USER_ID = "userId";
     public static final String ROLE = "role";
 
-    public static final int GITHUB_FOLLOW_QUERY_PAGING_SIZE = 2;
+    public static final int GITHUB_FOLLOW_QUERY_PAGING_SIZE = 100;
     public static final int GITHUB_MIN_REQUEST_THRESHOLD = 1000;
 
     public static final int OK = 200;

--- a/src/main/java/com/moyo/backend/githubfollow/controller/FollowRequest.java
+++ b/src/main/java/com/moyo/backend/githubfollow/controller/FollowRequest.java
@@ -1,0 +1,12 @@
+package com.moyo.backend.githubfollow.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FollowRequest {
+
+    private Long targetId;
+    private String targetUsername;
+}

--- a/src/main/java/com/moyo/backend/githubfollow/controller/GithubFollowController.java
+++ b/src/main/java/com/moyo/backend/githubfollow/controller/GithubFollowController.java
@@ -81,4 +81,5 @@ public class GithubFollowController {
 
         return ResponseEntity.ok().body(ApiResponse.noContent());
     }
+
 }

--- a/src/main/java/com/moyo/backend/githubfollow/controller/GithubFollowController.java
+++ b/src/main/java/com/moyo/backend/githubfollow/controller/GithubFollowController.java
@@ -19,12 +19,11 @@ public class GithubFollowController {
 
     private final GithubFollowService githubFollowService;
 
-
     @GetMapping("/users/me/followings/{detectType}")
     public ResponseEntity<ApiResponse<FollowDetectResponse>> getFollowUserList(@AuthenticationPrincipal GithubOAuth2User userPrincipal,
-                                                            @PathVariable("detectType") String detectType,
-                                                            @RequestParam(value = "lastUserId", required = false, defaultValue = "0") Long lastUserId,
-                                                            @RequestParam(value = "pageSize", required = false, defaultValue = "10") int pageSize){
+                                                                               @PathVariable("detectType") String detectType,
+                                                                               @RequestParam(value = "lastUserId", required = false, defaultValue = "0") Long lastUserId,
+                                                                               @RequestParam(value = "pageSize", required = false, defaultValue = "10") int pageSize){
 
         FollowDetectRequest request = FollowDetectRequest.builder()
                 .lastUserId(lastUserId)
@@ -35,36 +34,47 @@ public class GithubFollowController {
                 .build();
 
         long startTime = System.currentTimeMillis();
-        FollowDetectResponse response = githubFollowService.detectFollowUserList(request);
+        FollowDetectResponse response = githubFollowService.getFollowUserList(request);
 
         log.info("동기식 맞팔 탐지기 요청 소요 시간 : {}",System.currentTimeMillis() - startTime);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @PostMapping("/follow/{username}")
+    @DeleteMapping("/users/me/followings")
+    public ResponseEntity<ApiResponse<Void>> syncGithubFollowCache(@AuthenticationPrincipal GithubOAuth2User userPrincipal){
+
+        githubFollowService.deleteCache(userPrincipal.getId());
+
+        return ResponseEntity.ok(ApiResponse.noContent());
+    }
+
+    @PostMapping("/users/me/follow")
     public ResponseEntity<ApiResponse<Void>> followGithubUser(@AuthenticationPrincipal GithubOAuth2User githubOAuth2User,
-                                                              @PathVariable("username") String username){
+                                                              @RequestBody FollowRequest followRequest){
 
         FollowCommandRequest request = FollowCommandRequest.builder()
                 .currentUserId(githubOAuth2User.getId())
                 .currentUserPrincipalName(githubOAuth2User.getName())
-                .targetUsername(username)
+                .targetUsername(followRequest.getTargetUsername())
+                .targetUserId(followRequest.getTargetId())
                 .build();
 
         githubFollowService.follow(request);
 
-        return ResponseEntity.ok().body(ApiResponse.noContent());
+        return ResponseEntity.ok(ApiResponse.noContent());
     }
 
-    @DeleteMapping("/unfollow/{username}")
+    @DeleteMapping("/users/me/unfollow/{username}/{userId}")
     public ResponseEntity<ApiResponse<Void>> unFollowGithubUser(@AuthenticationPrincipal GithubOAuth2User githubOAuth2User,
-                                                                @PathVariable("username") String username){
+                                                                @PathVariable("username") String username,
+                                                                @PathVariable("userId") Long targetUserId){
 
         FollowCommandRequest request = FollowCommandRequest.builder()
                 .currentUserId(githubOAuth2User.getId())
                 .currentUserPrincipalName(githubOAuth2User.getName())
                 .targetUsername(username)
+                .targetUserId(targetUserId)
                 .build();
 
         githubFollowService.unfollow(request);

--- a/src/main/java/com/moyo/backend/githubfollow/dto/FollowCommandRequest.java
+++ b/src/main/java/com/moyo/backend/githubfollow/dto/FollowCommandRequest.java
@@ -10,4 +10,5 @@ public class FollowCommandRequest {
     private Long currentUserId;
     private String currentUserPrincipalName;
     private String targetUsername;
+    private Long targetUserId;
 }

--- a/src/main/java/com/moyo/backend/githubfollow/dto/FollowDetectResponse.java
+++ b/src/main/java/com/moyo/backend/githubfollow/dto/FollowDetectResponse.java
@@ -1,5 +1,6 @@
 package com.moyo.backend.githubfollow.dto;
 
+import com.moyo.backend.githubfollow.model.FollowUser;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,6 +10,6 @@ import java.util.List;
 @Builder
 public class FollowDetectResponse {
 
-    private List<GithubFollowUser> githubFollowUserList;
+    private List<FollowUser> userList;
     private boolean lastPage;
 }

--- a/src/main/java/com/moyo/backend/githubfollow/dto/GithubFollowUserResponse.java
+++ b/src/main/java/com/moyo/backend/githubfollow/dto/GithubFollowUserResponse.java
@@ -6,15 +6,15 @@ import lombok.Getter;
 
 @Getter
 @EqualsAndHashCode
-public class GithubFollowUser {
+public class GithubFollowUserResponse {
 
     private final Long id;
     private final String username;
     private final String profileImgUrl;
 
-    public GithubFollowUser(@JsonProperty("id")Long id,
-                            @JsonProperty("login") String login,
-                            @JsonProperty("avatar_url") String avatarUrl) {
+    public GithubFollowUserResponse(@JsonProperty("id")Long id,
+                                    @JsonProperty("login") String login,
+                                    @JsonProperty("avatar_url") String avatarUrl) {
         this.id = id;
         this.username = login;
         this.profileImgUrl = avatarUrl;

--- a/src/main/java/com/moyo/backend/githubfollow/dto/UserFollowCommandMeta.java
+++ b/src/main/java/com/moyo/backend/githubfollow/dto/UserFollowCommandMeta.java
@@ -1,5 +1,6 @@
 package com.moyo.backend.githubfollow.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import static com.moyo.backend.common.constant.MoyoConstants.GITHUB_MIN_REQUEST_THRESHOLD;
@@ -8,11 +9,33 @@ import static com.moyo.backend.common.constant.MoyoConstants.GITHUB_MIN_REQUEST_
 public class UserFollowCommandMeta {
 
     private final Integer rateLimitRemaining;
+    private final Long targetUserId;
+    private final String targetUsername;
+    private final String targetUserProfileImgUrl;
 
-    public UserFollowCommandMeta(Integer rateLimitRemaining) {
+    @Builder
+    private UserFollowCommandMeta(Integer rateLimitRemaining, Long targetUserId, String targetUsername, String targetUserProfileImgUrl) {
+        this.targetUserId = targetUserId;
+        this.targetUsername = targetUsername;
+        this.targetUserProfileImgUrl = targetUserProfileImgUrl;
+
         if (rateLimitRemaining < GITHUB_MIN_REQUEST_THRESHOLD)
             throw new RuntimeException("깃허브에 너무 많은 요청을 보내고 있습니다.");
 
         this.rateLimitRemaining = rateLimitRemaining;
     }
+
+    // 아이디는 그대로인데 이름이 변경된 경우
+    public boolean isTargetUserNameChanged(Long requestUserId, String requestUsername) {
+
+        return targetUserId.equals(requestUserId) && !targetUsername.equals(requestUsername);
+    }
+
+    // 요청 수행이 불가능 함. username을 통해 얻어온 Id가 달라서 완전히 다른 유저인 경우
+    public boolean isInvalidRequest(Long requestUserId){
+        return !targetUserId.equals(requestUserId);
+    }
+
+
+
 }

--- a/src/main/java/com/moyo/backend/githubfollow/infra/GithubFollowClientImpl.java
+++ b/src/main/java/com/moyo/backend/githubfollow/infra/GithubFollowClientImpl.java
@@ -1,9 +1,10 @@
 package com.moyo.backend.githubfollow.infra;
 
-import com.moyo.backend.githubfollow.dto.GithubFollowUser;
+import com.moyo.backend.githubfollow.dto.GithubFollowUserResponse;
 import com.moyo.backend.githubfollow.dto.UserFollowCommandMeta;
 import com.moyo.backend.githubfollow.dto.UserFollowDetectMeta;
 import com.moyo.backend.githubfollow.dto.UserFollowStats;
+import com.moyo.backend.githubfollow.model.FollowUser;
 import com.moyo.backend.githubfollow.service.GithubFollowClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.ParameterizedTypeReference;
@@ -61,37 +62,52 @@ public class GithubFollowClientImpl implements GithubFollowClient {
     }
 
     @Override
-    public UserFollowCommandMeta getUserFollowCommandMeta(String accessToken, String username) {
+    public UserFollowCommandMeta getUserFollowCommandMeta(String accessToken, String targetUsername) {
 
         ResponseEntity<?> response = restClient.get()
-                .uri("/users/{username}", username)
+                .uri("/users/{username}", targetUsername)
                 .headers(header -> header.setBearerAuth(accessToken))
                 .retrieve()
-                .toBodilessEntity();
+                .toEntity(GithubFollowUserResponse.class);
 
         int rateLimitRemaining = Integer.parseInt(response.getHeaders().get("X-RateLimit-Remaining").getFirst());
 
-        return new UserFollowCommandMeta(rateLimitRemaining);
+        GithubFollowUserResponse userResponse = (GithubFollowUserResponse) response.getBody();
+
+        return UserFollowCommandMeta.builder()
+                .rateLimitRemaining(rateLimitRemaining)
+                .targetUserId(userResponse.getId())
+                .targetUsername(userResponse.getUsername())
+                .targetUserProfileImgUrl(userResponse.getProfileImgUrl())
+                .build();
     }
 
     // 깃허브 페이지는 1부터 시작
     @Override
-    public List<GithubFollowUser> getFollowingList(String accessToken, int curPage){
+    public List<FollowUser> getFollowingList(String accessToken, int curPage){
 
-        return restClient.get()
+        List<GithubFollowUserResponse> userResponses = restClient.get()
                 .uri("/user/following?per_page=" + GITHUB_FOLLOW_QUERY_PAGING_SIZE +"&page=" + curPage)
                 .headers(header -> header.setBearerAuth(accessToken))
                 .retrieve()
                 .body(new ParameterizedTypeReference<>() {});
+
+        return userResponses.stream()
+                .map(userResponse -> new FollowUser(userResponse.getId(), userResponse.getUsername(), userResponse.getProfileImgUrl()))
+                .toList();
     }
 
     @Override
-    public List<GithubFollowUser> getFollowerList(String accessToken, int curPage) {
+    public List<FollowUser> getFollowerList(String accessToken, int curPage) {
 
-        return restClient.get()
+        List<GithubFollowUserResponse> userResponses = restClient.get()
                 .uri("/user/followers?per_page="+ GITHUB_FOLLOW_QUERY_PAGING_SIZE+ "&page=" + curPage)
                 .headers(header -> header.setBearerAuth(accessToken))
                 .retrieve()
                 .body(new ParameterizedTypeReference<>() {});
+
+        return userResponses.stream()
+                .map(userResponse -> new FollowUser(userResponse.getId(), userResponse.getUsername(), userResponse.getProfileImgUrl()))
+                .toList();
     }
 }

--- a/src/main/java/com/moyo/backend/githubfollow/infra/GithubFollowRepositoryRedisImpl.java
+++ b/src/main/java/com/moyo/backend/githubfollow/infra/GithubFollowRepositoryRedisImpl.java
@@ -1,0 +1,149 @@
+package com.moyo.backend.githubfollow.infra;
+
+import com.moyo.backend.githubfollow.model.FollowUser;
+import com.moyo.backend.githubfollow.service.GithubFollowRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class GithubFollowRepositoryRedisImpl implements GithubFollowRepository {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisTemplate<String, FollowUser> followUserRedisTemplate;
+
+    @Override
+    public boolean existByUserId(Long currentUserId) {
+
+        String followCacheKey = currentUserId + ":follow:time";
+        return stringRedisTemplate.hasKey(followCacheKey);
+    }
+
+    @Override
+    public void saveFollowCreatedAt(Long currentUserId, LocalDateTime now) {
+        String followCacheKey = currentUserId + ":follow:time";
+        String followingListKey = currentUserId + ":follow:followings";
+        String followerListKey = currentUserId + ":follow:followers";
+        int ttl = 300;
+
+        DefaultRedisScript<Void> script = new DefaultRedisScript<>();
+        script.setScriptText(
+                "redis.call('SET', KEYS[1], ARGV[1]) " +  // follow:time 저장
+                        "redis.call('EXPIRE', KEYS[1], ARGV[2]) " + // TTL 설정
+                        "redis.call('EXPIRE', KEYS[2], ARGV[2]) " + // TTL 동기화
+                        "redis.call('EXPIRE', KEYS[3], ARGV[2]) "
+        );
+        script.setResultType(Void.class);
+
+        List<String> keys = Arrays.asList(followCacheKey, followingListKey, followerListKey);
+        String formattedDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+        stringRedisTemplate.execute(script, keys, formattedDate, String.valueOf(ttl));
+    }
+
+    @Override
+    public void saveFollowingList(Long currentUserId, List<FollowUser> followings) {
+
+        String followingListKey = currentUserId + ":follow:followings";
+
+        for(FollowUser user : followings) {
+            followUserRedisTemplate.opsForZSet().add(followingListKey, user, user.getId());
+        }
+    }
+
+    @Override
+    public void saveFollowerList(Long currentUserId, List<FollowUser> followers) {
+
+        String followerListKey = currentUserId + ":follow:followers";
+
+        for(FollowUser user : followers) {
+            followUserRedisTemplate.opsForZSet().add(followerListKey, user, user.getId());
+        }
+    }
+
+    @Override
+    public List<FollowUser> getFollowingList(Long currentUserId) {
+
+        String followingListKey = currentUserId + ":follow:followings";
+
+        Set<FollowUser> members = followUserRedisTemplate.opsForZSet().range(followingListKey, 0, -1);
+        return new ArrayList<>(members);
+    }
+
+    @Override
+    public List<FollowUser> getFollowerList(Long currentUserId) {
+
+        String followingListKey = currentUserId + ":follow:followers";
+
+        Set<FollowUser> members = followUserRedisTemplate.opsForZSet().range(followingListKey, 0, -1);
+        return new ArrayList<>(members);
+    }
+
+    @Override
+    public void deleteFollowCache(Long currentUserId) {
+
+        String followCacheKey = currentUserId + ":follow:time";
+        String followingListKey = currentUserId + ":follow:followings";
+        String followerListKey = currentUserId + ":follow:followers";
+
+        stringRedisTemplate.delete(followCacheKey);
+        followUserRedisTemplate.delete(followingListKey);
+        followUserRedisTemplate.delete(followerListKey);
+    }
+
+    @Override
+    public void saveFollowing(Long currentUserId, FollowUser followUser) {
+
+        String followingListKey = currentUserId + ":follow:followings";
+        followUserRedisTemplate.opsForZSet().add(followingListKey, followUser, followUser.getId());
+    }
+
+    @Override
+    public void saveFollower(Long targetUserId, FollowUser followUser) {
+
+        String followerListKey = targetUserId + ":follow:followers";
+        followUserRedisTemplate.opsForZSet().add(followerListKey, followUser, followUser.getId());
+    }
+
+    @Override
+    public void deleteFollowingUser(Long currentUserId, Long targetUserId) {
+
+        String followingListKey = currentUserId + ":follow:followings";
+
+        // targetUserId를 score로 가지는 유저 한 명 가져오기
+        FollowUser userToRemove = followUserRedisTemplate.opsForZSet()
+                .rangeByScore(followingListKey, targetUserId, targetUserId)
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        followUserRedisTemplate.opsForZSet().remove(followingListKey, userToRemove);
+    }
+
+    @Override
+    public void deleteFollowerUser(Long targetUserId, Long currentUserId) {
+
+        String followerListKey = targetUserId + ":follow:followers";
+
+        // currentUserId를 score로 가지는 FollowUser 찾기
+        FollowUser userToRemove = followUserRedisTemplate.opsForZSet()
+                .rangeByScore(followerListKey, currentUserId, currentUserId)
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        followUserRedisTemplate.opsForZSet().remove(followerListKey, userToRemove);
+    }
+
+
+}

--- a/src/main/java/com/moyo/backend/githubfollow/model/FollowUser.java
+++ b/src/main/java/com/moyo/backend/githubfollow/model/FollowUser.java
@@ -1,0 +1,21 @@
+package com.moyo.backend.githubfollow.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+@NoArgsConstructor
+public class FollowUser {
+
+    private Long id;
+    private String username;
+    private String profileImgUrl;
+
+    public void changeUsername(String username){
+        this.username = username;
+    }
+}

--- a/src/main/java/com/moyo/backend/githubfollow/service/GithubFollowClient.java
+++ b/src/main/java/com/moyo/backend/githubfollow/service/GithubFollowClient.java
@@ -1,8 +1,8 @@
 package com.moyo.backend.githubfollow.service;
 
-import com.moyo.backend.githubfollow.dto.GithubFollowUser;
 import com.moyo.backend.githubfollow.dto.UserFollowCommandMeta;
 import com.moyo.backend.githubfollow.dto.UserFollowDetectMeta;
+import com.moyo.backend.githubfollow.model.FollowUser;
 
 import java.util.List;
 
@@ -16,7 +16,8 @@ public interface GithubFollowClient {
 
     UserFollowCommandMeta getUserFollowCommandMeta(String oauthAccessToken, String username);
 
-    List<GithubFollowUser> getFollowingList(String accessToken, int curPage);
+    List<FollowUser> getFollowingList(String accessToken, int curPage);
 
-    List<GithubFollowUser> getFollowerList(String accessToken, int curPage);
+    List<FollowUser> getFollowerList(String accessToken, int curPage);
+
 }

--- a/src/main/java/com/moyo/backend/githubfollow/service/GithubFollowRepository.java
+++ b/src/main/java/com/moyo/backend/githubfollow/service/GithubFollowRepository.java
@@ -1,0 +1,30 @@
+package com.moyo.backend.githubfollow.service;
+
+import com.moyo.backend.githubfollow.model.FollowUser;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface GithubFollowRepository {
+    boolean existByUserId(Long currentUserId);
+
+    void saveFollowCreatedAt(Long currentUserId, LocalDateTime now);
+
+    void saveFollowingList(Long currentUserId, List<FollowUser> followings);
+
+    void saveFollowerList(Long currentUserId, List<FollowUser> followers);
+
+    List<FollowUser> getFollowingList(Long currentUserId);
+
+    List<FollowUser> getFollowerList(Long currentUserId);
+
+    void deleteFollowCache(Long userId);
+
+    void saveFollowing(Long currentUserId, FollowUser followUser);
+
+    void saveFollower(Long targetUserId, FollowUser currentUser);
+
+    void deleteFollowingUser(Long currentUserId, Long targetUserId);
+
+    void deleteFollowerUser(Long targetUserId, Long currentUserId);
+}

--- a/src/main/java/com/moyo/backend/githubfollow/service/GithubFollowService.java
+++ b/src/main/java/com/moyo/backend/githubfollow/service/GithubFollowService.java
@@ -48,11 +48,15 @@ public class GithubFollowService {
             UserFollowDetectMeta followDetectMeta = githubFollowClient.getUserFollowDetectMeta(oauthAccessToken, user.getUsername());
             logFollowDetectMeta(request.getCurrentUserId(), followDetectMeta);
 
+            long startTime = System.currentTimeMillis();
+
             for (int page=1; page <= followDetectMeta.getMaxFollowingPage(); page++)
                 followings.addAll(githubFollowClient.getFollowingList(oauthAccessToken, page));
 
             for (int page=1; page <= followDetectMeta.getMaxFollowerPage(); page++)
                 followers.addAll(githubFollowClient.getFollowerList(oauthAccessToken, page));
+
+            log.info("팔로우 네트워크 응답 시간 측정 : {}", System.currentTimeMillis() - startTime);
 
             githubFollowRepository.saveFollowingList(request.getCurrentUserId(), followings);
             githubFollowRepository.saveFollowerList(request.getCurrentUserId(), followers);

--- a/src/main/java/com/moyo/backend/githubfollow/service/GithubFollowService.java
+++ b/src/main/java/com/moyo/backend/githubfollow/service/GithubFollowService.java
@@ -1,6 +1,7 @@
 package com.moyo.backend.githubfollow.service;
 
 import com.moyo.backend.githubfollow.dto.*;
+import com.moyo.backend.githubfollow.model.FollowUser;
 import com.moyo.backend.user.User;
 import com.moyo.backend.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,7 +9,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import static com.moyo.backend.common.constant.MoyoConstants.GITHUB_FOLLOW_QUERY_PAGING_SIZE;
 import static com.moyo.backend.common.constant.MoyoConstants.GITHUB_REGISTRATION_ID;
@@ -20,22 +25,46 @@ public class GithubFollowService {
 
     private final UserRepository userRepository;
     private final GithubFollowClient githubFollowClient;
+    private final GithubFollowRepository githubFollowRepository;
     private final OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
-    public FollowDetectResponse detectFollowUserList(FollowDetectRequest request) {
 
-        User user = userRepository.findById(request.getCurrentUserId()).orElseThrow(() -> new IllegalArgumentException("해당 ID의 사용자를 찾을 수 없습니다: " + request.getCurrentUserId()));
-        String oauthAccessToken = getOAuthAccessToken(request.getCurrentUserPrincipalName());
-        UserFollowDetectMeta followDetectMeta = githubFollowClient.getUserFollowDetectMeta(oauthAccessToken, user.getUsername());
-        logFollowDetectMeta(request.getCurrentUserId(), followDetectMeta);
+    public FollowDetectResponse getFollowUserList(FollowDetectRequest request){
 
-        Set<GithubFollowUser> followingsSet = new LinkedHashSet<>();
-        Set<GithubFollowUser> followersSet = new LinkedHashSet<>();
+        User user = userRepository.findById(request.getCurrentUserId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 사용자를 찾을 수 없습니다: " + request.getCurrentUserId()));
 
-        for (int page=1; page <= followDetectMeta.getMaxFollowingPage(); page++)
-            followingsSet.addAll(githubFollowClient.getFollowingList(oauthAccessToken, page));
+        List<FollowUser> followings = new ArrayList<>();
+        List<FollowUser> followers = new ArrayList<>();
 
-        for (int page=1; page <= followDetectMeta.getMaxFollowerPage(); page++)
-            followersSet.addAll(githubFollowClient.getFollowerList(oauthAccessToken, page));
+        Set<FollowUser> followingsSet = new LinkedHashSet<>();
+        Set<FollowUser> followersSet = new LinkedHashSet<>();
+
+        // Redis Lazy Loading
+        if(!githubFollowRepository.existByUserId(request.getCurrentUserId())){
+
+            log.info("캐시에 {}의 팔로잉 관련 데이터가 존재 하지 않음.", request.getCurrentUserId());
+
+            String oauthAccessToken = getOAuthAccessToken(request.getCurrentUserPrincipalName());
+            UserFollowDetectMeta followDetectMeta = githubFollowClient.getUserFollowDetectMeta(oauthAccessToken, user.getUsername());
+            logFollowDetectMeta(request.getCurrentUserId(), followDetectMeta);
+
+            for (int page=1; page <= followDetectMeta.getMaxFollowingPage(); page++)
+                followings.addAll(githubFollowClient.getFollowingList(oauthAccessToken, page));
+
+            for (int page=1; page <= followDetectMeta.getMaxFollowerPage(); page++)
+                followers.addAll(githubFollowClient.getFollowerList(oauthAccessToken, page));
+
+            githubFollowRepository.saveFollowingList(request.getCurrentUserId(), followings);
+            githubFollowRepository.saveFollowerList(request.getCurrentUserId(), followers);
+            githubFollowRepository.saveFollowCreatedAt(request.getCurrentUserId(), LocalDateTime.now());
+
+            followingsSet.addAll(followings);
+            followersSet.addAll(followers);
+        }
+        else {
+            followingsSet.addAll(githubFollowRepository.getFollowingList(request.getCurrentUserId()));
+            followersSet.addAll(githubFollowRepository.getFollowerList(request.getCurrentUserId()));
+        }
 
         switch (request.getDetectType()) {
             case "mutual" -> followingsSet.retainAll(followersSet);
@@ -44,16 +73,17 @@ public class GithubFollowService {
             default -> throw new IllegalArgumentException("잘못된 FollowType: " + request.getDetectType());
         }
 
-        List<GithubFollowUser> githubFollowUserList = new ArrayList<>();
+        List<FollowUser> followUserList = new ArrayList<>();
         switch (request.getDetectType()) {
-            case "mutual", "following-only" -> githubFollowUserList.addAll(followingsSet);
-            case "follower-only" -> githubFollowUserList.addAll(followersSet);
+            case "mutual", "following-only" -> followUserList.addAll(followingsSet);
+            case "follower-only" -> followUserList.addAll(followersSet);
         }
 
-        List<GithubFollowUser> pagingList = new ArrayList<>();
+
+        List<FollowUser> pagingList = new ArrayList<>();
         boolean lastPage = true;
 
-        for(GithubFollowUser followUser : githubFollowUserList){
+        for(FollowUser followUser : followUserList){
 
             if(request.getLastUserId() == 0 || followUser.getId() > request.getLastUserId()) pagingList.add(followUser);
 
@@ -64,39 +94,98 @@ public class GithubFollowService {
             }
         }
 
-
         return FollowDetectResponse.builder()
-                .githubFollowUserList(pagingList)
+                .userList(pagingList)
                 .lastPage(lastPage)
                 .build();
     }
 
     public void follow(FollowCommandRequest request) {
 
-        User user = userRepository.findById(request.getCurrentUserId()).orElseThrow(() -> new IllegalArgumentException("해당 ID의 사용자를 찾을 수 없습니다: " + request.getCurrentUserId()));
         String oauthAccessToken = getOAuthAccessToken(request.getCurrentUserPrincipalName());
+        UserFollowCommandMeta followCommandMeta = githubFollowClient.getUserFollowCommandMeta(oauthAccessToken, request.getTargetUsername());
+        FollowUser followUser = new FollowUser(request.getTargetUserId(), request.getTargetUsername(), followCommandMeta.getTargetUserProfileImgUrl());
 
-        UserFollowCommandMeta followCommandMeta = githubFollowClient.getUserFollowCommandMeta(oauthAccessToken, user.getUsername());
-        log.info("{}의 남은 요청 수 : {}",request.getCurrentUserId(),followCommandMeta.getRateLimitRemaining());
+        if (followCommandMeta.isInvalidRequest(request.getTargetUserId())){
+            log.warn("팔로우 하려는 사람이 닉네임을 변경했고 해당 이름을 다른 사용자가 사용하는 중임");
 
+            throw new RuntimeException("팔로우 하려는 사람이 닉네임을 변경했고 해당 이름을 다른 사용자가 사용하는 중임");
+        }
+
+        // 팔로우 하려는 사람의 닉네임이 변경됨
+        if (followCommandMeta.isTargetUserNameChanged(request.getTargetUserId(), request.getTargetUsername())) {
+            log.info("팔로우 하려는 사람의 닉네임이 변경됨 {} -> {}", request.getTargetUsername(), followCommandMeta.getTargetUsername());
+            followUser.changeUsername(followCommandMeta.getTargetUsername());
+        }
+
+        log.info("{}의 남은 요청 수 : {}", request.getCurrentUserId(), followCommandMeta.getRateLimitRemaining());
         log.info("깃허브 팔로우 요청 | 요청자 ID : {} -> {}", request.getCurrentUserId(), request.getTargetUsername());
 
-        if(githubFollowClient.follow(request.getTargetUsername(), oauthAccessToken) != 204)
+        if (githubFollowClient.follow(request.getTargetUsername(), oauthAccessToken) != 204)
             throw new RuntimeException("깃허브 팔로우 중 에러 발생");
+
+        // write through
+        // 내가 상대를 팔로우 캐시에 추가, 사용자가 화면을 띄워둔채로 캐시 만료 후 요청 날릴걸 대비
+        if (githubFollowRepository.existByUserId(request.getCurrentUserId())){
+
+            githubFollowRepository.saveFollowing(request.getCurrentUserId(), followUser);
+
+            User user = userRepository.findById(request.getCurrentUserId()).get();
+
+            // 상대의 팔로우 캐시가 존재 하고 우리 서비스의 유저 라면 상대의 팔로우 캐시에도 추가
+            if(githubFollowRepository.existByUserId(request.getTargetUserId())){
+
+                FollowUser currentUser = new FollowUser(user.getId(), user.getUsername(), user.getProfileImgUrl());
+                githubFollowRepository.saveFollower(request.getTargetUserId(), currentUser);
+            }
+        }
+
     }
 
     public void unfollow(FollowCommandRequest request) {
 
-        User user = userRepository.findById(request.getCurrentUserId()).orElseThrow(() -> new IllegalArgumentException("해당 ID의 사용자를 찾을 수 없습니다: " + request.getCurrentUserId()));
         String oauthAccessToken = getOAuthAccessToken(request.getCurrentUserPrincipalName());
 
-        UserFollowCommandMeta followCommandMeta = githubFollowClient.getUserFollowCommandMeta(oauthAccessToken, user.getUsername());
+        UserFollowCommandMeta followCommandMeta = githubFollowClient.getUserFollowCommandMeta(oauthAccessToken, request.getTargetUsername());
         log.info("{}의 남은 요청 수 : {}",request.getCurrentUserId(),followCommandMeta.getRateLimitRemaining());
+
+        FollowUser followUser = new FollowUser(request.getTargetUserId(), request.getTargetUsername(), followCommandMeta.getTargetUserProfileImgUrl());
+
+        if (followCommandMeta.isInvalidRequest(request.getTargetUserId())){
+            log.warn("언 팔로우 하려는 사람이 닉네임을 변경 했고 해당 이름을 다른 사용자가 사용하는 중임");
+
+            throw new RuntimeException("언 팔로우 하려는 사람이 닉네임을 변경 했고 해당 이름을 다른 사용자가 사용하는 중임");
+        }
+
+        // 언 팔로우 하려는 사람의 닉네임이 변경됨
+        if (followCommandMeta.isTargetUserNameChanged(request.getTargetUserId(), request.getTargetUsername())) {
+            log.info("언 팔로우 하려는 사람의 닉네임이 변경됨 {} -> {}", request.getTargetUsername(), followCommandMeta.getTargetUsername());
+            followUser.changeUsername(followCommandMeta.getTargetUsername());
+        }
 
         log.info("깃허브 언 팔로우 요청 | 요청자 ID : {} -> {}", request.getCurrentUserId(), request.getTargetUsername());
 
-        if(githubFollowClient.unfollow(request.getTargetUsername(), oauthAccessToken) != 204)
+        if(githubFollowClient.unfollow(followUser.getUsername(), oauthAccessToken) != 204)
             throw new RuntimeException("깃허브 언 팔로우 중 에러 발생");
+
+        // 내 팔로잉 캐시에서 해당유저 제거
+        if(githubFollowRepository.existByUserId(request.getCurrentUserId())){
+
+            githubFollowRepository.deleteFollowingUser(request.getCurrentUserId(), request.getTargetUserId());
+
+            // 상대의 팔로워에서 나 제거
+            if(githubFollowRepository.existByUserId(request.getTargetUserId())){
+
+                githubFollowRepository.deleteFollowerUser(request.getTargetUserId(), request.getCurrentUserId());
+            }
+        }
+
+    }
+
+
+    public void deleteCache(Long userId) {
+
+        githubFollowRepository.deleteFollowCache(userId);
     }
 
     private String getOAuthAccessToken(String userPrincipalName){

--- a/src/main/java/com/moyo/backend/security/jwt/util/JwtProvider.java
+++ b/src/main/java/com/moyo/backend/security/jwt/util/JwtProvider.java
@@ -15,8 +15,8 @@ import static com.moyo.backend.common.constant.MoyoConstants.*;
 @Component
 public class JwtProvider {
 
-    private static final long JWT_ACCESS_EXPIRES_MS = 1000 * 60 * 10;
-    private static final long JWT_REFRESH_EXPIRES_MS = 1000 * 60 * 100;
+    private static final long JWT_ACCESS_EXPIRES_MS = 1000 * 60 * 100;
+    private static final long JWT_REFRESH_EXPIRES_MS = 1000 * 60 * 1000;
 
 
     private final SecretKey secretKey;

--- a/src/main/java/com/moyo/backend/security/oauth/repository/LoginRepositoryImpl.java
+++ b/src/main/java/com/moyo/backend/security/oauth/repository/LoginRepositoryImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.Date;
@@ -13,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class LoginRepositoryImpl implements LoginRepository{
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final StringRedisTemplate redisTemplate;
 
     @Override
     public void save(Long userId, String refreshToken, Date expiration) {


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #44 

## ☑️ 완료 태스크
- [x] 맞팔 탐지기 중간 캐시 추가

<br />

## 🔎 PR 내용

이전에 #43 PR에서 언급했던 여러가지 문제들 중, 깃허브에서 사용자의 팔로잉, 팔로워를 가져온 후 이를 가공한 다음 맞팔로우 한 사람, 나만 팔로우한 사람, 상대만 나를 팔로우 한 사람들을 페이징 해서 보여줄 때 API 서버에서 너무 비효율적으로 많은 자원을 사용하는 문제를 해결하기 위해 중간 캐시를 도입했어요!

아직 전체적인 맞팔 탐지기 설계가 완전히 끝나지 않고 이런저런 것들을 도입해 보면서 테스트 하고 있어서 돌아만 가는 코드를 작성중입니다. 따라서 코드레벨에서의 리뷰 말고 전체적인 구상이 어떤지 리뷰해 주시면 좋을거 같아요! @zzaekkii  @semi-yu 
<br />


## 1️⃣ 맞팔 탐지기 구현 중 발생한 문제

우선 이전 V1 PR에서 사용자가 맞팔 탐지기 결과 리스트에서 자신이 보고 있는 마지막 UserId를 넘겨주면 그 UserId 뒤의 User로 부터 30 명의 유저를 추가 적으로 조회하는 방식으로 데이터가 사라지거나 중복되는 문제를 해결했어요!
<br />

![image](https://github.com/user-attachments/assets/73cb14c1-57fd-48d7-9131-9c5dd0974e02)

![image](https://github.com/user-attachments/assets/85672d18-4efd-4b1c-9738-bf8d9668ea3d)

이번 V2에서 해결할 문제는 위의 그림 처럼 사용자가 자신의 맞팔리스트를 조회해 보고 싶어서 요청을 날릴 때 마다 API 서버에서 깃허브에 있는 데이터를 모두 받아와서 이를 가공 후 페이징 요구사항에 맞는 페이지를 넘겨줘야 하기 떄문에 깃허브와 너무 많은 네트워크 통신을 하고 매 페이지 요청 마다 성능이 매우 느린 문제입니다.

<br/>

여기서 참고로 매번 깃허브에서 사용자의 팔로잉, 팔로워 정보를 다 가져와야 하냐, 우리는 사용자가 보내오는 lastUserId도 가지고 있으니까 paging size에 맞춰서 100 명씩 일단 가져와서 데이터를 가공해 보고 paging size 보다 부족하면 다시 데이터를 또 깃허브에서 가져오면 안되냐? 라는 의문이 들 수 있습니다. 

<br/>

![image](https://github.com/user-attachments/assets/8094aafe-19a0-473c-83ee-209a9aaf9070)

우리 서비스 기획 상 전체 맞팔로워가 몇명인지 알려줘야 하기 때문에 적어도 한 번은 전체 팔로잉, 팔로워 데이터를 받아와서 이를 계산해야 하기도 하고

우리 서비스의 대부분의 예상 사용자들의 전체 팔로잉 팔로워가 보통 200명 내외, 정말 정말 많아야 2000명 정도로 예상하고 있기 때문에 한번에 데이터를 받아와도 괜찮을 거 같아서 어느정도 트레이드 오프 하기도 했습니다.

물론 이에 관한 문제는 추후 다른 이슈에서 한번 더 다룰 것입니다. 이번 PR에서 주된 문제는 어쨌든 우리 API 서버에서 사용자의 팔로워, 팔로잉 데이터를 저장하지 않으면 매 페이지 요청마다 깃허브와 과도한 네트워크 통신 비용이 발생하고 성능이 느려진다는 점입니다.
<br/>

## 2️⃣ API 서버에 사용자의 깃허브 팔로잉, 팔로워 데이터를 캐시한다면?

위의 문제를 해결하기 위해서 우리 사용자의 깃허브 팔로잉, 팔로워를 우리가 캐싱해서 사용하면 어떨까? 라는 생각을 했습니다.

여기서 최대한 실시간 맞팔 탐지기를 만들어서 깃허브 상의 데이터와 우리가 제공하는 데이터의 정합성을 100%로 맞춰주고 싶었습니다.

이전의 매번 깃허브 상에 데이터를 요청하는 방식에서는 이게 가능했지만 사용자의 팔로잉, 팔로워를 우리가 캐싱하는 시점부터는 우리 쪽에서 보여주는 데이터와 깃허브상의 실제 데이터가 동기화 되지 않을 수 있습니다.

그렇다고 초단위의 주기로 깃허브에 데이터를 요청하고 동기화 하기에는 비용이 너무 많이 들것 같았습니다. 우리 서비스의 기획 요구사항에서 맞팔 탐지기는 최대한 빠른 응답을 우선시 해줬으면 좋겠고 깃허브와 데이터 강제동기화 버튼과 최종 동기화 시점을 함께 제공하자고 했었습니다.

<br/>

따라서 이런 요구사항을 최대한 반영해서 그렇다면 우리 서비스 외부에서 발생하는 깃허브 사용자 팔로우, 언팔로우는 우리가 매번 체크할 수 없으니 완전 실시간 반영을 포기하고 데이터 동기화 버튼과 최종 동기화 시점을 제공해서 해결하는 것으로 하고

![image](https://github.com/user-attachments/assets/76676177-39cf-4dcf-aa71-7c0f93d93c9e)

우리 서비스 내에서 팔로우/언팔로우 이벤트가 발생하면 위와 같이 Write Through 전략을 사용 할 생각입니다. 이에 대해서는 아래에서 더 자세히 설명할게요!

<br/>

![image](https://github.com/user-attachments/assets/456e4516-cad8-4188-8765-9718cc837199)
![image](https://github.com/user-attachments/assets/648d9873-cbea-4e8f-9eb4-1f3ed5a8813e)

데이터 조회시에는 위와 같은 전략을 사용할 생각입니다. 깃허브를 실제 데이터가 저장된 메인저장소, 우리 측에 RDB나 NoSQL을 이용해서 이를 캐싱 할  생각이에요. 

<br/>


## 3️⃣ 그럼 어떤 형식으로 데이터를 어디에 저장할까?

우선 데이터를 캐싱하는 것 까지는 좋은데 그럼 데이터를 어떤 형식으로 저장할지가 의문이었습니다. 

![image](https://github.com/user-attachments/assets/6c475a7d-fa01-418d-9f6c-77da3079cde3)

깃허브에서 보내오는 팔로잉, 팔로워 유저에 대한 데이터는 크게 위와 같았습니다. 여기서 id는 절대 변하지 않지만 나머지 값은 언제나 변할 수 있습니다.

처음에는 우선 우리의 RDB를 깃허브 데이터를 위한 캐시 저장소로 사용하는 것이 어떨까? 라는 생각을 했습니다. 

![image](https://github.com/user-attachments/assets/e784b594-b5e9-45e4-8cde-9af2f68dd889)

위와 같이 데이터를 저장해서 중복된 데이터도 관리하고 조인이나 서브쿼리를 이용하면 쉽게 맞팔로우, 나만 팔로우, 상대만 나를 팔로우한 유저를 관리해 줄 수 있겠다라는 생각을 했습니다.

<br/>

하지만 현실적으로 우리 유저들간의 팔로잉, 팔로워가 서로 겹칠일이 그렇게 많지는 않을거 같다는 생각이 들었고 굳이 우리가 GithubUser들 까지 Entity로 저장해두고 id를 기준으로 매번 변경된 데이터가 있는지 체크해주고 username 변경, 프로필 이미지 변경 까지 관리해 줄 필요가 있나? 라는 생각이 들었습니다.

그냥 깔끔하게 데이터를 받아와서 모두 저장해 두고 다시 데이터를 받아올때 해당 사용자의 모든 팔로잉 캐시 데이터를 날려버리고 다시 저장하는게 좋지 않을까? 라고 생각했어요. 

![image](https://github.com/user-attachments/assets/fc826065-1360-41ed-9a29-3dc753546a98)

즉, DB에 이렇게 해당 유저의 팔로잉, 팔로워를 자체를 유지하다가 전체 삭제, 전체 저장을 통해 관리하는게 더 좋지 않을까? 라는 생각이었습니다. 그런데 위와 같은 구조로 데이터를 저장할거면 굳이 RDB에 저장하지 않아도 되겠다는 생각이 들었습니다. 우선 follow, followed, githubuser 3개의 테이블로 중복된 데이터를 최소화하는 구조에서 following, follower로 반정규화를 진행하긴 했는데

어차피 이렇게 저장해두고 매번 데이터를 날렸다가 다시 저장했다가 하면서 데이터를 동기화 할거면 쓰기작업이 너무 많이 발생한다고 생각했습니다. 우리는 RDB로 특히나 MySQL을 사용하고 있고 MySQL은 상대적으로 읽기가 빠르고 쓰기가 느린 DB입니다.

이럴거면 차라리 캐시로 많이 활용되는 Redis를 사용하는게 좋겠다고 생각했습니다.

![image](https://github.com/user-attachments/assets/c508bfb5-2c34-4b2e-9917-7653ede70460)

위의 그림은 비슷한 형식의 데이터 1000개, 즉 팔로잉, 팔로워 데이터 1000개를 한 번의 커넥션을 통해서 저장하는데 Redis와 MySQL에서 성능 비교를 간단하게 진행한 사진입니다.

MySQL의 경우 동일한 테이블에 여러명의 데이터가 계속 쓰기, 삭제가 되야하기 때문에 지금 보다 훨씬 더 느려질 수 있습니다. 또한 추후 많은 데이터가 생기면서 인덱스를 걸어주게 되면 더더욱 느려질 수 있습니다.

<br/>

![image](https://github.com/user-attachments/assets/7d1059e4-7220-465a-a3b2-e9f3ffc62643)

반면 Redis를 캐시로 사용할 경우, 데이터가 계속 쌓이게 되면 In Memory DB인 Redis의 특성상 메모리 공간이 부족해 질 수 있는 문제가 있습니다. 우리 프로젝트에서는 AWS Free Tier Elastic Cache를 사용할 것이고 사용할 수 있는 메모리 공간은 400 MB 정도입니다. 

![image](https://github.com/user-attachments/assets/8790d9dc-50b1-4e59-82ff-db97acc9e09f)

따라서 Redis를 캐시로 사용하고 위와 같은 형식의 데이터를 저장해야 겠다고 생각했어요!
<br/>


## 4️⃣ Redis를 사용하면서 생길 수 있는 문제와 사용 계획

Redis를 캐시로 사용하기로 확정하면서 크게 2가지 문제점을 발견했어요! 

<br/> 

### 1. 레디스의 모든 공간이 가득 차면 어떻게 대응 할 것인가? 

지금 우리에게 할당된 Elastic Cache 프리티어 메모리 용량은 416MB입니다. 만약 맞팔 탐지기가 너무 흥행해서 동시에 데이터를 사용하는 사용자들이 과하게 많아진다면 레디스의 저장공간이 부족해지는 날이 올 수 있어요.

이 경우 일단 AWS의 오토 스케일링을 통해서 Scale Up을 진행해 볼 수 있지만, 우리 프로젝트에서는 예산 상의 문제로 Redis를 2개이상 두지는 않을 계획 입니다. 프리티어는 1개의 Redis만 무료로 지원합니다.

Redis의 저장공간이 부족해 진다면 Redis의 메모리 관리 전략을 선택해 줄 수 있어요 레디스의 maxmemory-policy를 조정해서 현재 메모리의 사용량이 maxmemory에 도달했을 때 Redis에게 어떤식으로 메모리 관리를 하게 할지 정해 줄 수 있습니다.

예를들어  maxmemory-policy를 noeviction으로 설정한다면 메모리가 가득찾으니 요청을 거부하고 에러를 반환하게 만들 수 있어요.

같은 맥락으로 우리는 maxmemory-policy를 volatile-ttl로 설정해서 현재 ttl이 가장 적게 남은 키를 삭제하는 방식을 선택할 생각이에요.

위에서 언급했듯이 각각의 데이터는 5분정도의 TTL을 갖게 할 생각이고 레디스는 거대한 캐시로만 사용할 생각입니다. 영구적으로 데이터를 저장하지 않습니다. 보통은 Redis를 사용할 때 매우 빈번하게 조회되는 데이터를 Redis에 저장하는 전략을 많이 사용하는데 우리의 경우는 이와는 좀 다른 전략을 사용할 생각입니다.

![image](https://github.com/user-attachments/assets/865710c7-c81e-4b0e-812d-ca8adab42eec)

맞팔 탐지기를 사용하는 사용자의 경우 위와 같은 화면을 받아 볼거고 보통 Slice 화면을 계속 내리면서 자신의 전체 맞팔로워를 둘러보거나 여기서 팔로우, 언팔로우 요청을 하고, 새로고침을 눌러서 잘 반영 되었는지 확인해 보는 등의 상호작용을 할 것으로 예상 됩니다. 

따라서 사용자의 이런 행동 패턴을 생각해서 처음 깃허브와 데이터 동기화 시 받아온 모든 데이터를 5~10 분정도의 짧은 시간동안 캐싱해두고 사용할 생각입니다. 

만약 사용자가 맞팔 탐지기를 오랫동안 사용해서 사용하는 시점에 캐시가 비워진다면 해당 시점에 다시 깃허브와 데이터 동기화를 진행하고 사용자가 보내온 lastUserId를 기반으로 사용자가 보고 싶었던 화면에 다시 응답하는 구조로 설계했어요!

![image](https://github.com/user-attachments/assets/0f0c6f8b-2b26-45b5-af32-3fecf222e1b5)

즉, 읽기 관점에서 지연로딩 패턴을 적용했습니다.
 
<br/>

### 2. Redis 서버가 다운 되었을 때 맞팔 탐지기 자체가 마비되면 안된다.

두번째 중요한 문제는 Redis가 알수 없는 이유로 다운 되었을 때 이는 속도 향상을 위한 캐시에 불과하기 때문에 맞팔탐지기 서비스 자체가 마비되지 않게 해야한다는 점 이었습니다.

![image](https://github.com/user-attachments/assets/eb57e955-8139-42c5-8bf7-6e7d32ebfeb1)

이는 위에서 설명했다시피 읽기 관점에서 지연로딩 패턴을 사용했기 때문에 성능이 안좋아진다는 점 빼고는 문제될 게 없습니다.

대신, Redis가 다운 된 상황에서도 문제없이 API가 수행되어야 하기 때문에 Redis의 루아 스크립트 (MySQL 프로시져 같은 역할)등을 사용해서 비즈니스 로직 일부를 DB에 위임하는 선택지는 사용할 수 없다고 생각했습니다.

 물론 비즈니스 로직을 DB에 둘지 WAS에 둘지는 갑론을박이 있지만 우리 프로젝트의 경우 DB가 외부 API이고 캐시가 Redis인 상황이고 Redis 서버도 오직 한 개로만 운영하기 때문에 Redis에서 followers ∩ followings 같은 연산을 통해서 맞팔로우 리스트를 가져오는 등의 선택지는 절대로 사용할 수 없게 됩니다.

WAS의 입장에서는 followers, followings가 외부 API를 통해서 도착할지 캐시를 통해서 도착할지 알 수 없기 때문에 모두 WAS에서 가공할 생각입니다.

<br/>

![image](https://github.com/user-attachments/assets/287a0d3b-7c8d-4841-9423-4cfe16ae6d6c)

그럼 팔로우, 언팔로우 같은 쓰기 이벤트에서도 문제가 안 생길지만 생각해 보면 되는데 팔로우를 예로 들어 보겠습니다.
팔로우의 경우 위와 같이 Write through 패턴을 사용할 생각입니다. 생각보다 단순하지 않은 여러가지 이벤트들이 발생합니다.
언팔로우도 위와 마찬가지 입니다.

![image](https://github.com/user-attachments/assets/3606aaf5-6243-41c5-8e77-acc7e875d86e)

현재 구조에서 이런 이벤트 들은 Redis가 다운 되더라도 전혀 문제 없이 동작하게 됩니다.


## 5️⃣ Redis를 스프링 앱에서 어떻게 이용하나요?

이제 맞팔 탐지기V2의 구상을 모두 마쳤으니 실제 구현을 해야하는데 Redis를 스프링 앱에서 어떻게 사용할 수 있을지를 생각해 봐야 했습니다. 코드 레벨에서 Redis를 사용해 보는 것은 처음이라 공부했던 내용을 PR로 공유하겠습니다!

[Spring Data Redis 공식문서](https://docs.spring.io/spring-data/redis/reference/)

레디스를 실제 코드 레벨에서 사용하기 위해서 위의 Spring Data Redis 공식문서를 참고 했습니다. 


<br/>

### Lettuce vs Jedis vs Redission

 자바 진영에서 쉽게 Redis를 사용하기 위한 RedisClient 라이브러리로 크게 Lettuce, Jedis, Redission 3가지 선택지가 있었습니다. 
[Redis 공식문서 블로그] (https://redis.io/blog/jedis-vs-lettuce-an-exploration/) 

레디스 공식문서에 Lettuce와 Jedis를 비교해주는 친절한 포스팅이 있었습니다. 내용을 정리해 보자면 Lettuce는 비동기 방식을 지원하는 Redis Java 클라이언트고 파이프라이닝, 클러스터, 센티넬 등등 Redis의 고급 기능을을 지원한다고 합니다.

Jedis의 경우 가볍고 단순한 구조의 Redis Java 클라이언트고 사용하기 쉬운 대신 기능이 제한적이고 비동기 처리가 불가능 하다는 단점이 있는 라이브러리 라고 합니다.

Lettuce와 Jedis중에서 저는 Lettuce를 선택했습니다. Redis를 사용하면서 어떤 이슈가 발생할지 모르는데 제한적인 기능을 지원하고 비동기자체를 지원하지 않는 Jedis를 사용하는 것은 좋지 않아 보였습니다. 그냥 처음부터 Lettuce를 사용하는게 좋을거 같습니다. 

아래에서 다루겠지만 Spring Data Redis를 사용할 때 Redis 클라이언트 구현체를 갈아끼는 건 크게 문제가 되지는 않아요! 

[Lettuce vs Jedis 분석 블로그 글](https://jojoldu.tistory.com/418) 

또한 위의 글을 한번 읽어 보시면 굳이 Jedis를 사용할 이유가 없겠다는 생각이 듭니다. 추가적으로 대부분의 Redis 교육용 자료, 참고 프로젝트들이 Lettuce를 사용하고 있어서 참고 자료가 많은 Lettuce를 사용하기로 했습니다.

<br/>

![image](https://github.com/user-attachments/assets/b7352af5-0537-4637-908e-0688f7eb71e2)

Spring Data Redis의 공식 문서를 살펴보면 Lettuce와 Jedis는 기본적으로 연동을 지원하는데 Redission은 그렇지 않은 것 같아서 일단은 선택지에서 제외했습니다. 

우리가 지금 하고 싶은 건 Spring Data Redis에서 기본으로 지원해주는 Lettuce나 Jedis를 이용해서 Repository기능을 사용하고 싶은 것인데 Redission의 경우 주로 Redis를 이용한 분산락 같은 상대적으로 고급기능을 구현할 때 Lettuce보다 더 효율적인 솔루션을 제공해서 많이들 사용하는 것 같습니다. 우리 프로젝트에서는 현재 사용 용도에 가장 적합한 Lettuce를 사용하는게 좋아 보였습니다.

<br/>

정리하자면 스프링 쪽에서 주로 Lettuce, Jedis를 편애한다. 그 중에서 Lettuce를 사용하자!



### Spring Redis 연결 설정

이번 PR에서는 Redis의 아주 기본적인 부분만 작업할 생각입니다. 예를 들어서 Redis의 기본 설정들을 튜닝하는 등의 작업은 더 공부후 별도의 이슈에서 작업하겠습니다.

![image](https://github.com/user-attachments/assets/e597bf6d-7c58-4132-a9a1-efc250436765)

우리가 Redis 클라이언트로 Lettuce를 쓰든 Jedis를 쓰든, Spring에서는 RedisConnectionFactory라는 공통된 인터페이스를 통해 통일된 방식으로 Redis와 연결을 관리합니다.

<br/>
공식문서를 계속 보면 RedisConnectionFactory에서 RedisConnection이 생성되고 RedisConnection을 통해서 Redis와 통신해요. 또한 Lettuce를 사용하다가 Lettuce라이브러리에서 정의한 고유의 에러가 발생하면 RedisConnection에서 스프링 고유 예외인 DataAceessException으로 자동 변환해서 던져 줍니다.

즉 스프링의 @Repository를 사용하지 않아도 이미 Lettuce 예외가 스프링 예외로 변환되어 던져지는게 보장 됩니다.

<br/>

여기서 RedisConnection은 Thread safe 하지 않게 설계되어 있다는 문제가 있습니다. 즉 여러 스레드가 RedisConnection을 공유해서 사용하면 동시성 문제가 발생할 수 있습니다.

예를 들어 Redis 에는 파이프라이닝 이라는 기술이 있습니다. 네트워크 회수를 줄이기 위해서 클라이언트가 보내오는 명령을 바로바로 응답하지 않고 모아뒀다가 한번에 응답해 주는 기술인데 RedisConnection이 여러 사용자에게 공유되고 Thread safe 하지 않다면 이는 큰 문제가 됩니다. 

즉, RedisConnection은 내부에 final이 아닌 필드들을 가지고 있으니 절대 여러 스레드에서 공유하면 안된다는 얘기 입니다. 이런 필드를 가지고 있는 이유는 RedisConnection을 이용해서 트랜잭션, 파이프라이닝 등등의 레디스 고급 기능을 사용할 수 있게 지원해 주기 위해서 입니다.

공식문서를 살펴보면 이는 잘못된 설계가 아니라 일부러 이렇게 만들었다고 해요.


<br/>

```
@Configuration
class RedisConfig {

  @Bean
  public RedisConnectionFactory redisConnectionFactory() {

    return new LettuceConnectionFactory(new RedisStandaloneConfiguration("server", 6379));
  }
}

```

위와 같이 수동 스프링 빈 등록을 이용해서 RedisConnectionFactory의 구현체인 LettuceConnectionFactory를 스프링 빈으로 등록해 주고 여기서 LettuceConnection들을 만들어서 사용하면 스프링과 레디스를 연결할 수있습니다. 세션 타임 아웃등의 고급 설정은 다른 이슈에서 진행할게요. 


이후 RedisTemplate라는 것을 스프링 빈으로 등록해 줍니다.

```

@Bean
  RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {

    RedisTemplate<String, String> template = new RedisTemplate<>();
    template.setConnectionFactory(connectionFactory);
    return template;
  }

```

앞서서 RedisConnectionFactory를 통해서 RedisConnection을 생성해서 이를 통해서 레디스와 스프링이 통신 할 수 있다고 했는데 RedisConnection은 트랜잭션, 파이프라이닝 등의 기능을 지원하기 위해서 Thread Safe 하지 않게 설계 되었다고 했습니다.

이런 RedisConnection의 생명주기나 동시성 문제를 신경 쓰지 않기 위해서 RedisTemplate에게 RedisConnectionFactory를 전달하고 개발자는 RedisTemplate만을 신경쓰면서 개발 할 수 있습니다. RedisTemplate은 스프링 빈으로 등록해도 ThreadSafe하고 상황에 맞게 레디스 사용시 RedisConnection을 새로 만들어 주거나 기존의 RedisConnection을 유지 시켜 줍니다.

RedisTemplate는 이런 RedisConnection에 대한 멀티 쓰레딩 환경에서의 안전성을 보장해주고 추가적으로 여러가지 역할들을 해줍니다.
<br/>

```
 RedisTemplate<String, MyCustomObject> myRedisTemplate = new RedisTemplate<>();
 RedisTemplate<String, String> stringRedisTemplate = new RedisTemplate<>();

```
Redis와의 상호작용을 간편하고 추상화된 방식으로 제공하며, opsForValue(), opsForHash() 등 다양한 RedisOperations API를 사용할 수 있도록 도와줍니다. 

즉 개발자는 자신의 원하는 형태의 Key : Value 데이터 저장 구조를 설계해 두고 RedisConnectionFactory를 RedisTemplate에 전달해서 쉽게 자신에게 맞는 템플릿을 만들 수 있고 만들어진 템플릿에서는 redis의 다양한 기능들을 위한 RedisOperations를 제공해 줍니다.

<br/>

```  
StringRedisTemplate redisTemplate = new StringRedisTemplate();
```
또한 자주 사용될 법한 템플릿은 이미 다 만들어져 있습니다.



<br/>

![image](https://github.com/user-attachments/assets/373e40b7-5856-4094-9fa9-827e0ea5b19a)

Redis는 내부적으로 모든 데이터를 byte[] 형태로 저장합니다. 따라서 내가 저장하고 싶은 어떤 객체든 직렬화 역직렬화 과정을 반드시 거쳐야 합니다. 이런 과정은 Spring Data Redis의 Serializer에서 지원해주고 있고 어떤 객체든 Jackson2JsonRedisSerializer, GenericJackson2JsonRedisSerializer를 이용해서 저장 가능합니다.

저장하려는 객체의 타입이 명확하게 고정되어 있다면 Jackson2JsonRedisSerializer을 어떤 객체든 역직렬화 하고 싶거나 Object를 저장하려면  GenericJackson2JsonRedisSerializer을 사용하면 됩니다.

<br/>

![image](https://github.com/user-attachments/assets/cebdd183-7de8-4631-b59a-730c782db1bf)

만약 위와 같은 FollowUser 라는 커스텀 클래스를 Redis에 저장하고 싶을 때 두가지 직렬화기를 사용하면 

![image](https://github.com/user-attachments/assets/859bd482-688b-4471-baf7-970a486b0a5e)

![image](https://github.com/user-attachments/assets/7d489a85-8b36-4eb7-aa4e-a99a3a69f054)

위와 같이 단순히 직렬화만 할 것이냐, 클래스 메타 정보까지 다 저장 할 것이냐에 대한 차이가 있습니다. 보안이나 성능을 위해서 Jackson2JsonRedisSerializer을 사용할 생각입니다. 캐시할 유저의 클래스가 계속 변하거나 유동적이라면 GenericJackson2JsonRedisSerializer를 사용했겠지만 우리의 경우 정확히 하나의 타입으로 고정할 생각이기 때문에 Jackson2JsonRedisSerializer이 올바른 선택인 것 같습니다.


<br/>
이렇게 스프링에서 편리하게 레디스를 사용할 수 있게 되었습니다.

참고로 조금 더 간단히 어노테이션 수준으로 메서드 레벨에서 레디스에 간단한 캐싱을 하기 위해 Redis Cache를 사용할 수도 있는데 트랜잭션 관리, 비동기 작업등 조금 복잡하게 레디스를 사용해야 한다면 직접 Redis Template를 이용하는게 좋을거 같습니다.

<br/>

## 6️⃣ 실제 데이터를 레디스에 저장하기

어떤 사용자가 맞팔로우 탐지기를 이용한다면 우리는 캐시에 해당사용자의 데이터 캐싱시점, followings, followers를 저장해야 합니다. 

![image](https://github.com/user-attachments/assets/4814cdc1-aeff-412f-afb8-109e3a220511)

처음에는 위와 같은 형식으로 데이터를 캐싱할까 생각해 봤습니다. 하지만 이런 방식으로 데이터를 저장하면 사용자가 우리 서비스에서 새로운 유저를 팔로우 하거나 언팔로우 하게 될 경우, followings, followers 전체 json문자열을 꺼내와서 이를 수정해야 하는 비효율이 생깁니다.

![image](https://github.com/user-attachments/assets/c39f775b-054b-4494-9920-d4e4a3bb7cde)

위와 같은 방식으로 데이터를 나누어 저장하는 것을 생각해 봤습니다. ZSET은 Redis에서 제공하는 기본자료형으로 score를 기준으로 정렬된 SET 이라고 생각하면 됩니다.

score로는 userId를 활용 했습니다. 깃허브에서 API 응답 자체를 userId 순으로 주기도 하고 사용자가 페이징 요청을 처리할때 사용자가 보내온 lastUserId를 기준으로 페이징을 하기도 하니 미리 userId 기준으로 정렬해 두는게 편할 것이라고 생각했어요!

물론 이는 아직 초기 구상일 뿐이라서 언제든지 다른 아이디어 주셔도 괜찮습니다. 여튼 저는 사용자들의 특정 값으로 미리 정렬된 형태의 데이터를 저장해 두면 추후 WAS에서 추가적인 정렬이 필요하지 않을 거 같았습니다. (물론 Username 순이라면 추가 처리가 필요)

또한, 새로운 팔로우, 언팔로우가 발생했을 때 이를 처리하기 위해서 해당 사용자의 캐시에 데이터 하나만 넣어주면 알아서 자신의 위치에 정렬되어 저장되니까 편하게 사용 할 수 있지 않을까? 라고 생각 했습니다.

 <br/>


## #️⃣ 기타 참고 사항

@zzaekkii @semi-yu 
우선 코드 레벨에서의 리뷰는 안해도 될거 같습니다. 지금은 그냥 작동만 어떻게든 되게 만들고 있어서 코드레벨이 엉망 진창입니다. 추후 Redis 트랜잭션, 파이프라이닝, 루아 등을 더 공부해서 레디스 사용시 성능 최적화, 트랜잭션 보장, 예외처리를 적용한 다음 마지막으로 외부 API 호출 비동기 처리 까지만 적용한 후에 제대로 리팩토링해서 아키텍처, 테스트 코드, OOP들을 적용해 보고 부탁 드릴게요!

당분간은 학교 중간고사 기간이라 작업을 많이는 못할거 같습니다..  

  