### PR TITLE
Fix: 로그인 리팩토링 후 클래스명, 패키지 위치 변경으로 인한 컴파일 에러 수정

### DIFF
--- a/src/main/java/com/moyo/backend/common/dto/ApiResponse.java
+++ b/src/main/java/com/moyo/backend/common/dto/ApiResponse.java
@@ -1,39 +1,39 @@
 package com.moyo.backend.common.dto;
 
-    import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-    import com.moyo.backend.common.exception.ErrorReason;
-    import lombok.AccessLevel;
-    import lombok.AllArgsConstructor;
-    import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.moyo.backend.common.exception.ErrorReason;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-    import static com.moyo.backend.common.constant.MoyoConstants.NO_CONTENT;
-    import static com.moyo.backend.common.constant.MoyoConstants.OK;
+import static com.moyo.backend.common.constant.MoyoConstants.NO_CONTENT;
+import static com.moyo.backend.common.constant.MoyoConstants.OK;
 
-    @Getter
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    @JsonPropertyOrder({"status", "code", "message", "data"})
-    public class ApiResponse <T>{
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"status", "code", "message", "data"})
+public class ApiResponse <T>{
 
-        private final int status;
+    private final int status;
 
-        private final String code;
+    private final String code;
 
-        private final String message;
+    private final String message;
 
-        private final T data;
+    private final T data;
 
-        public static <S> ApiResponse<S> success(S data){
+    public static <S> ApiResponse<S> success(S data){
 
-            return new ApiResponse<>(OK, "OK", null, data);
-        }
-
-        public static <S> ApiResponse<S> noContent(){
-
-            return new ApiResponse<>(NO_CONTENT, "NO_CONTENT", null, null);
-        }
-
-        public static <S> ApiResponse<S> fail(ErrorReason errorReason){
-
-            return new ApiResponse<>(errorReason.getStatus(), errorReason.getCode(), errorReason.getErrorMessage(), null);
-        }
+        return new ApiResponse<>(OK, "OK", null, data);
     }
+
+    public static <S> ApiResponse<S> noContent(){
+
+        return new ApiResponse<>(NO_CONTENT, "NO_CONTENT", null, null);
+    }
+
+    public static <S> ApiResponse<S> fail(ErrorReason errorReason){
+
+        return new ApiResponse<>(errorReason.getStatus(), errorReason.getCode(), errorReason.getErrorMessage(), null);
+    }
+}

--- a/src/main/java/com/moyo/backend/pr_review/presentation/PrReviewController.java
+++ b/src/main/java/com/moyo/backend/pr_review/presentation/PrReviewController.java
@@ -1,12 +1,12 @@
 package com.moyo.backend.pr_review.presentation;
 
-import com.moyo.backend.common.model.ApiResponse;
+import com.moyo.backend.common.dto.ApiResponse;
+import com.moyo.backend.pr_review.application.PrReviewService;
 import com.moyo.backend.pr_review.dto.request.PrReviewCreateRequestDto;
 import com.moyo.backend.pr_review.dto.request.PrReviewListRequestDto;
 import com.moyo.backend.pr_review.dto.request.PrReviewUpdateRequestDto;
 import com.moyo.backend.pr_review.dto.response.*;
-import com.moyo.backend.pr_review.application.PrReviewService;
-import com.moyo.backend.security.oauth.dto.GithubOAuth2User;
+import com.moyo.backend.security.oauth.GithubOAuth2User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/moyo/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/moyo/backend/security/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/health", "/").permitAll()               // Health Check
                         .requestMatchers("/permit/all/test").permitAll()             // Test
-                        .requestMatchers("/auth/only/test").hasRole("ADMIN")
+                        .requestMatchers("/auth/test/admin").hasRole("ADMIN")
                         .requestMatchers("/error/**","/favicon.ico" ).permitAll()  // Default
                         .requestMatchers("/auth/reissue/token").permitAll()          // Token Reissue
                         .anyRequest().authenticated())


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #23 

## ☑️ 완료 태스크
- [x] 패키지 명 변경
- [x] ADMIN 테스트 경로 수정 

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->

여러 곳에서 공통으로 사용되는 로그인 쪽을 리팩토링 하면서 이에 의존하는 여러 코드에 영향이 있었습니다. 이를 모두 수정했고 ADMIN 권한 테스트 권한이 잘못된 경로로 세팅 된것도 발견해서 수정했습니다. 

<br />
