### PR TITLE
Fix: Swagger UI 관련 CORS 설정

### DIFF
--- a/src/main/java/com/moyo/backend/common/config/MvcCorsConfig.java
+++ b/src/main/java/com/moyo/backend/common/config/MvcCorsConfig.java
@@ -8,15 +8,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import static com.moyo.backend.common.constant.MoyoConstants.AUTHORIZATION;
 
 @Configuration
-public class MVCCorsConfig implements WebMvcConfigurer {
+public class MvcCorsConfig implements WebMvcConfigurer {
 
     @Value("${spring.cors.allow-origin}")
-    private String allowOrigin;
+    private String allowOrigins;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins(allowOrigin)
+                .allowedOrigins(allowOrigins.split(","))
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .exposedHeaders(AUTHORIZATION)


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #56 

## ☑️ 완료 태스크
- [x] Swagger를 이용한 문서 자동화 도입 후, CORS 설정 누락으로 인한 버그 해결

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->

배포된 서버에 Swagger UI를 이용한 API 문서를 도입했었는데 CORS 설정이 프론트 로컬환경 (localhost:5173)으로만 설정되어 있어서 실제api.서버 에서 Swagger를 이용한 API 테스트를 실행할 경우 CORS 문제가 터지던 걸 해결했습니다!  