### PR TITLE
Fix: Fixed bug with Redis immutable list JSON serialization

### DIFF
--- a/src/main/java/com/moyo/backend/domain/github_follow/implement/GithubFollowRelation.java
+++ b/src/main/java/com/moyo/backend/domain/github_follow/implement/GithubFollowRelation.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -84,6 +85,6 @@ public class GithubFollowRelation {
 
 		return githubFollowings.stream()
 			.map(GithubUser::id)
-			.toList();
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/moyo/backend/domain/github_follow/implement/GithubUser.java
+++ b/src/main/java/com/moyo/backend/domain/github_follow/implement/GithubUser.java
@@ -13,3 +13,4 @@ public record GithubUser(
 		return this.id.compareTo(otherUser.id);
 	}
 }
+	


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #78 

## ☑️ 완료 태스크
- [x] GithubFollowRelation getMethod 내부 불변 리스트 -> 가변 리스트로 변환

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->

![image](https://github.com/user-attachments/assets/8d6a13f7-7a5d-42a1-baa8-603de2dead54)

서버에서 에러로그 발생시 디스코드 알람을 받을 수 있게하자마자 무수히 많은 에러가 발생했습니다.

에러 로그를 살펴보니 Spring Cache로 Redis를 사용하던중 JSON 직렬화 / 역직렬화를 사용하게 되는데, 이 때, List.of(), 같은 방식으로 불변 리스트를 사용하고 있다면 JSON 직렬화/역직렬화가 정상적으로 수행되지 않는 문제가 발생합니다.

<br/>

```java

return githubFollowings.stream()
			.map(GithubUser::id)
			.toList()

```
문제의 코드는 위의 부분 이었습니다.

![image](https://github.com/user-attachments/assets/350554fd-2b17-46ea-b5a8-734d1aa96ea6)

자바 16부터 추가된 toList()는 불변 리스트를 반환하고 있습니다.

<br/>

```java

return githubFollowings.stream()
			.map(GithubUser::id)
			.collect(Collectors.toList());

```

반면 위와 같이 Collectors.toList()를 이용할 경우

<br/>

![image](https://github.com/user-attachments/assets/9f0f250b-7cd7-4750-a6f2-384c6ab7f99d)

불변 리스트를 반환하지 않기 때문에 해당 부분을 수정했습니다!


