### PR TITLE
Deploy: test server migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
 name: Moyo API Test Server Deploy
 
-# AWS 프리티어 만료로 인한 배포 임시 비활성화
-#on:
-#  push:
-#    branches:
-#      - develop
-#    path: backend/**
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - backend/**
 
 jobs:
   Deploy:
@@ -40,33 +40,30 @@ jobs:
       - name: 빌드된 JAR 파일 이름 변경
         run: mv ./build/libs/*SNAPSHOT.jar ./project.jar
 
-      - name: EC2 서버로 JAR 파일 전송
-        uses: appleboy/scp-action@v0.1.7
+      - name: AWS 인증 설정
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: project.jar
-          target: /home/ubuntu/moyo-test/tobe
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
 
-      - name: SSH로 EC2에 접속 후 애플리케이션 실행
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
-          script_stop: true
-          script: |
-            source ${{ secrets.ENV_FILE_PATH }}
-            rm -rf /home/ubuntu/moyo-test/current
-            mkdir /home/ubuntu/moyo-test/current
-            mv /home/ubuntu/moyo-test/tobe/project.jar /home/ubuntu/moyo-test/current/project.jar
-            cd /home/ubuntu/moyo-test/current
-            
-            sudo fuser -k -n tcp 8080 || true
-            sudo fuser -k -n tcp 8081 || true
-  
-            nohup java -jar project.jar --spring.profiles.active=test --server.port=8080 &
-            nohup java -jar project.jar --spring.profiles.active=test --server.port=8081 &
-           
-            rm -rf /home/ubuntu/moyo-test/tobe
+      - name: S3로 JAR 업로드
+        run: aws s3 cp ./project.jar s3://${{ secrets.DEPLOY_S3_BUCKET }}/project.jar
+
+      - name: SSM RunCommand로 EC2에 배포 명령 실행
+        run: |
+          aws ssm send-command \
+            --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "Deploy from GitHub Actions" \
+            --parameters commands="
+              aws s3 cp s3://${{ secrets.DEPLOY_S3_BUCKET }}/project.jar /home/ubuntu/moyo-test/tobe/project.jar &&
+              rm -rf /home/ubuntu/moyo-test/current &&
+              mkdir /home/ubuntu/moyo-test/current &&
+              mv /home/ubuntu/moyo-test/tobe/project.jar /home/ubuntu/moyo-test/current/project.jar &&
+              cd /home/ubuntu/moyo-test/current &&
+              sudo fuser -k -n tcp 8080 || true &&
+              nohup java -jar project.jar --spring.profiles.active=test --server.port=8080 & 
+              rm -rf /home/ubuntu/moyo-test/tobe
+            " \
+            --output text

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
             --document-name "AWS-RunShellScript" \
             --comment "Deploy from GitHub Actions" \
             --parameters commands="
+              source ${{ secrets.TEST_ENV }} &&
               aws s3 cp s3://${{ secrets.DEPLOY_S3_BUCKET }}/project.jar /home/ubuntu/moyo-test/tobe/project.jar &&
               rm -rf /home/ubuntu/moyo-test/current &&
               mkdir /home/ubuntu/moyo-test/current &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,15 +56,18 @@ jobs:
             --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
             --comment "Deploy from GitHub Actions" \
-            --parameters commands="
-              source ${{ secrets.TEST_ENV }} &&
-              aws s3 cp s3://${{ secrets.DEPLOY_S3_BUCKET }}/project.jar /home/ubuntu/moyo-test/tobe/project.jar &&
-              rm -rf /home/ubuntu/moyo-test/current &&
-              mkdir /home/ubuntu/moyo-test/current &&
-              mv /home/ubuntu/moyo-test/tobe/project.jar /home/ubuntu/moyo-test/current/project.jar &&
-              cd /home/ubuntu/moyo-test/current &&
-              sudo fuser -k -n tcp 8080 || true &&
-              nohup java -jar project.jar --spring.profiles.active=test --server.port=8080 & 
-              rm -rf /home/ubuntu/moyo-test/tobe
-            " \
+            --parameters "commands=[
+              \"bash -c '
+                cd /root &&
+                source ${{ secrets.TEST_ENV }} &&
+                aws s3 cp s3://${{ secrets.DEPLOY_S3_BUCKET }}/project.jar /home/ubuntu/moyo-test/tobe/project.jar &&
+                rm -rf /home/ubuntu/moyo-test/current &&
+                mkdir /home/ubuntu/moyo-test/current &&
+                mv /home/ubuntu/moyo-test/tobe/project.jar /home/ubuntu/moyo-test/current/project.jar &&
+                cd /home/ubuntu/moyo-test/current &&
+                sudo fuser -k -n tcp 8080 || true &&
+                nohup java -jar project.jar --spring.profiles.active=test --server.port=8080 &
+                rm -rf /home/ubuntu/moyo-test/tobe
+              '\"
+            ]" \
             --output text

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ bootJar {
 
 openapi3 {
     servers = [
-            { url = "https://api.cafehub.site"},
+            { url = "https://moyoy-test.shop"},
             { url = "http://localhost:8080" }
     ]
     title = "Moyoy API Server"

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,6 @@ dependencies {
     // Logback
     implementation 'ca.pjer:logback-awslogs-appender:1.6.0'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
-
 }
 
 

--- a/src/main/java/com/moyo/backend/domain/batchLegacy/ranking/presentation/RankingBatchScheduler.java
+++ b/src/main/java/com/moyo/backend/domain/batchLegacy/ranking/presentation/RankingBatchScheduler.java
@@ -23,7 +23,7 @@ public class RankingBatchScheduler {
 
 	private final RankingBatchService rankingBatchService;
 
-	@Scheduled(cron = "00 02 * * * *")
+	@Scheduled(cron = "00 00 19 * * *")
 	public void dailyRankingBatch() {
 
 		rankingBatchService.launchRankingBatch();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,15 +47,6 @@ spring:
 logging:
   config: classpath:logging/logback-${spring.profiles.active:local}.xml
 
-# AWS
-cloud:
-  aws:
-    credentials:
-      accessKey: ${AWS_ACCESS_KEY_ID}
-      secretKey: ${AWS_SECRET_ACCESS_KEY}
-    region:
-      static: ${AWS_REGION}
-
 # Discord
 
 discord:


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #88 

## 🔎 PR 내용

기존 테스트 서버 AWS 프리티어 계정이 만료되어 새 계정으로 이전했습니다.

기존 테스트 서버는 public subnet에 ec2를 위치시키고 lb + api를 모두 담당하는 구조였는데

이번에 테스트용으로 ALB -> private ec2 api server로 변경했습니다.

이에 따라 배포도 ssh -> aws ssm + s3를 이용한 방법으로 변경했습니다. 