### PR TITLE
Fix: Resolve logging-related error

### DIFF
--- a/.github/workflows/api-test-deploy.yml
+++ b/.github/workflows/api-test-deploy.yml
@@ -62,5 +62,5 @@ jobs:
             mv /home/ubuntu/moyoy-test/api/tobe/moyoy-api.jar /home/ubuntu/moyoy-test/api/current/moyoy-api.jar
             cd /home/ubuntu/moyoy-test/api/current
             sudo fuser -k -n tcp 8080 || true    
-            nohup java -jar moyoy-api.jar --spring.profiles.active=test --server.port=8080 &
+            nohup java -jar moyoy-api.jar --spring.profiles.active=test > ./output.log 2>&1 &
             rm -rf /home/ubuntu/moyoy-test/api/tobe

--- a/.github/workflows/batch-test-deploy.yml
+++ b/.github/workflows/batch-test-deploy.yml
@@ -62,5 +62,5 @@ jobs:
             mv /home/ubuntu/moyoy-test/batch/tobe/moyoy-batch.jar /home/ubuntu/moyoy-test/batch/current/moyoy-batch.jar
             cd /home/ubuntu/moyoy-test/batch/current
             sudo fuser -k -n tcp 9000 || true    
-            nohup java -jar moyoy-batch.jar --spring.profiles.active=test --server.port=9000 &
+            nohup java -jar moyoy-batch.jar --spring.profiles.active=test > ./output.log 2>&1 &
             rm -rf /home/ubuntu/moyoy-test/batch/tobe

--- a/Moyoy-Api/src/main/resources/logback/logback-test.xml
+++ b/Moyoy-Api/src/main/resources/logback/logback-test.xml
@@ -4,9 +4,9 @@
 
 <!-- 텍스트 로그 (로컬/실시간/백업) -->
 <appender name="DAILY_API_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>/home/ubuntu/moyoy-api-test/logs/api.log</file>
+    <file>/home/ubuntu/moyoy-test/logs/api.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>/home/ubuntu/moyoy-api-test/api.%d{yyyy-MM-dd}.log</fileNamePattern>
+        <fileNamePattern>/home/ubuntu/moyoy-test/logs/api.%d{yyyy-MM-dd}.log</fileNamePattern>
         <maxHistory>2</maxHistory>
     </rollingPolicy>
     <encoder>
@@ -16,9 +16,9 @@
 
 <!-- JSON 로그 (CloudWatch 업로드용) -->
 <appender name="JSON_CLOUD_WATCH_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>/home/ubuntu/moyoy-api-test/logs/json.log</file>
+    <file>/home/ubuntu/moyoy-test/logs/api-json.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>/home/ubuntu/moyoy-api-test/json.%d{yyyy-MM-dd}.log</fileNamePattern>
+        <fileNamePattern>/home/ubuntu/moyoy-test/logs/api-json.%d{yyyy-MM-dd}.log</fileNamePattern>
         <maxHistory>2</maxHistory>
     </rollingPolicy>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/Moyoy-Batch/src/main/resources/logback/logback-test.xml
+++ b/Moyoy-Batch/src/main/resources/logback/logback-test.xml
@@ -4,9 +4,9 @@
 
 <!-- 텍스트 로그 (로컬/실시간/백업) -->
 <appender name="DAILY_BATCH_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>/home/ubuntu/moyoy-batch-test/logs/batch.log</file>
+    <file>/home/ubuntu/moyoy-test/logs/batch.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>/home/ubuntu/moyoy-batch-test/batch.%d{yyyy-MM-dd}.log</fileNamePattern>
+        <fileNamePattern>/home/ubuntu/moyoy-test/logs/batch.%d{yyyy-MM-dd}.log</fileNamePattern>
         <maxHistory>1</maxHistory>
     </rollingPolicy>
     <encoder>
@@ -16,9 +16,9 @@
 
 <!-- JSON 로그 (CloudWatch 업로드용) -->
 <appender name="JSON_CLOUD_WATCH_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>/home/ubuntu/moyoy-batch-test/logs/json.log</file>
+    <file>/home/ubuntu/moyoy-test/logs/batch-json.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>/home/ubuntu/moyoy-batch-test/json.%d{yyyy-MM-dd}.log</fileNamePattern>
+        <fileNamePattern>/home/ubuntu/moyoy-test/batch-json.%d{yyyy-MM-dd}.log</fileNamePattern>
         <maxHistory>3</maxHistory>
     </rollingPolicy>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/Moyoy-Batch/src/main/resources/logback/logback-test.xml
+++ b/Moyoy-Batch/src/main/resources/logback/logback-test.xml
@@ -18,7 +18,7 @@
 <appender name="JSON_CLOUD_WATCH_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>/home/ubuntu/moyoy-test/logs/batch-json.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>/home/ubuntu/moyoy-test/batch-json.%d{yyyy-MM-dd}.log</fileNamePattern>
+        <fileNamePattern>/home/ubuntu/moyoy-test/logs/batch-json.%d{yyyy-MM-dd}.log</fileNamePattern>
         <maxHistory>3</maxHistory>
     </rollingPolicy>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #issue_number

## ☑️ 완료 태스크
- [x] 배포시 무한 대기 문제 해결
- [x] 로그 파일 경로 불일치 해결

<br />

## 🔎 PR 내용

#93 이슈에서 발생한 문제들을 해결했습니다.


## 1️⃣ 배포 시 무한 대기 문제 해결

### 변경 내용
- EC2 배포 스크립트에서 `nohup ... java -jar ... &` 실행 방식을 `nohup ... > output.log 2>&1 &` 형태로 수정.
- stdout/stderr를 파일로 리다이렉션하여 GitHub Actions 로그에 출력되지 않도록 함.

### 원인
- 기존 배포 스크립트는 애플리케이션 실행 후 stdout/stderr가 SSH 세션에 연결되어 Actions가 종료되지 않음. API 서버가 종료되기 전까지 계속 로그를 출력하며 무한 대기하는 문제 발생.


<br/><br/>


## 2️⃣ 로그 파일 경로 불일치 문제 해결

logback 파일에서 로그를 저장하는 경로와 깃허브 액션 스크립트에서 서버관련 파일을 저장하는 경로가 달라서 발생한 문제를 해결했습니다!


