### PR TITLE
Feat: Add User Profile Retrieval

### DIFF
--- a/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/user/UserController.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/user/UserController.java
@@ -1,0 +1,32 @@
+package com.moyoy.api.presentation.v1.domain.user;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.moyoy.api.support.annotation.LoginUserId;
+import com.moyoy.api.support.response.ApiResponse;
+import com.moyoy.core.domain.user.business.UserProfileResult;
+import com.moyoy.core.domain.user.business.UserService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserController {
+
+	private final UserService userService;
+
+	@GetMapping("/users/me/profile")
+	public ResponseEntity<ApiResponse<UserProfileResponse>> userProfile(
+		@LoginUserId Long userId) {
+
+		UserProfileResult userProfileResult = userService.getUserProfile(userId);
+
+		UserProfileResponse responseData = UserProfileResponse.from(userProfileResult);
+
+		return ResponseEntity.ok(ApiResponse.success(responseData));
+	}
+}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/user/UserProfileResponse.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/user/UserProfileResponse.java
@@ -1,0 +1,25 @@
+package com.moyoy.api.presentation.v1.domain.user;
+
+import com.moyoy.core.domain.user.business.UserProfileResult;
+
+public record UserProfileResponse(
+	Long userId,
+	String username,
+	long rankPoint,
+	String rankGrade,
+	String profileImgUrl,
+	int followerCount,
+	int followingCount) {
+
+	public static UserProfileResponse from(UserProfileResult userProfileResult) {
+
+		return new UserProfileResponse(
+			userProfileResult.userId(),
+			userProfileResult.username(),
+			userProfileResult.yearlyRankPoint(),
+			userProfileResult.yearlyRankGrade(),
+			userProfileResult.profileImgUrl(),
+			userProfileResult.githubFollowerCount(),
+			userProfileResult.githubFollowingCount());
+	}
+}

--- a/Moyoy-Api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/Moyoy-Api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -144,6 +144,28 @@ paths:
                 LOGIN_401_5:
                   value: "{\"status\":401,\"code\":\"LOGIN_401_5\",\"message\":\"블\
                     랙리스트 처리된 토큰 입니다.\",\"data\":null}"
+  /api/v1/users/me/profile:
+    get:
+      tags:
+      - 🙋 유저 프로필
+      summary: 유저 개인 프로필 조회 API
+      description: 유저의 프로필 및 관련 데이터를 조회합니다.
+      operationId: 개인 프로필 조회 성공
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-me-profile1583212755"
+              examples:
+                개인 프로필 조회 성공:
+                  value: "{\"status\":200,\"code\":\"OK\",\"message\":null,\"data\"\
+                    :{\"userId\":1,\"username\":\"moyoy\",\"rankPoint\":10000,\"rankGrade\"\
+                    :\"A\",\"profileImgUrl\":\"http://~\",\"followerCount\":10,\"\
+                    followingCount\":20}}"
+      security:
+      - bearerAuthJWT: []
   /api/v1/users/me/followings/rankings:
     get:
       tags:
@@ -386,6 +408,51 @@ components:
               type: boolean
               description: 📌 마지막 페이지 여부
           description: 응답 데이터
+        status:
+          type: number
+          description: ✅ 응답 상태 코드
+    api-v1-users-me-profile1583212755:
+      required:
+      - code
+      - message
+      - status
+      type: object
+      properties:
+        code:
+          type: string
+          description: 🔢 응답 코드
+        data:
+          required:
+          - followerCount
+          - followingCount
+          - profileImgUrl
+          - rankGrade
+          - rankPoint
+          - userId
+          - username
+          type: object
+          properties:
+            rankGrade:
+              type: string
+              description: 📊 사용자 랭킹 등급
+            profileImgUrl:
+              type: string
+              description: 🖼️ 사용자 프로필 이미지 URL
+            followingCount:
+              type: number
+              description: 👥 GitHub 팔로잉 수
+            followerCount:
+              type: number
+              description: 👥 GitHub 팔로워 수
+            userId:
+              type: number
+              description: 👦 사용자 ID
+            rankPoint:
+              type: number
+              description: 🌟 사용자 랭킹 점수
+            username:
+              type: string
+              description: 🙋 사용자 이름
         status:
           type: number
           description: ✅ 응답 상태 코드

--- a/Moyoy-Api/src/test/java/com/moyoy/api/presentation/v1/domain/user/UserControllerTest.java
+++ b/Moyoy-Api/src/test/java/com/moyoy/api/presentation/v1/domain/user/UserControllerTest.java
@@ -1,0 +1,92 @@
+package com.moyoy.api.presentation.v1.domain.user;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static com.moyoy.common.constant.TestConstant.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+
+import com.moyoy.api.presentation.ApiControllerAdvice;
+import com.moyoy.common.annotation.WithMockMoyoyUser;
+import com.moyoy.core.domain.user.business.UserProfileResult;
+import com.moyoy.core.domain.user.business.UserService;
+
+@WebMvcTest(value = UserController.class, excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+	OncePerRequestFilter.class})})
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@Import(ApiControllerAdvice.class)
+class UserControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private UserService userService;
+
+	@Test
+	@WithMockMoyoyUser(id = 1)
+	void 유저_프로필_조회_문서화() throws Exception {
+
+		UserProfileResult mockServiceResult = new UserProfileResult(
+			1L,
+			"moyoy",
+			10000,
+			"A",
+			"http://~",
+			10,
+			20);
+
+		Mockito
+			.when(userService.getUserProfile(anyLong()))
+			.thenReturn(mockServiceResult);
+
+		mockMvc
+			.perform(
+				get("/api/v1/users/me/profile")
+					.header("Authorization", "Bearer " + MOCK_JWT_ACCESS_TOKEN))
+			.andExpect(status().isOk())
+
+			// REST Docs
+			.andDo(document("개인 프로필 조회 성공",
+				resource(ResourceSnippetParameters.builder()
+					.tag("🙋 유저 프로필")
+					.summary("유저 개인 프로필 조회 API")
+					.description("유저의 프로필 및 관련 데이터를 조회합니다.")
+					.responseFields(
+						fieldWithPath("status").description("✅ 응답 상태 코드"),
+						fieldWithPath("code").description("🔢 응답 코드"),
+						fieldWithPath("message").description("📝 응답 메시지"),
+						fieldWithPath("data.userId").description("👦 사용자 ID"),
+						fieldWithPath("data.username").description("🙋 사용자 이름"),
+						fieldWithPath("data.rankPoint").description("🌟 사용자 랭킹 점수"),
+						fieldWithPath("data.rankGrade").description("📊 사용자 랭킹 등급"),
+						fieldWithPath("data.profileImgUrl").description("🖼️ 사용자 프로필 이미지 URL"),
+						fieldWithPath("data.followerCount").description("👥 GitHub 팔로워 수"),
+						fieldWithPath("data.followingCount").description("👥 GitHub 팔로잉 수"))
+					.build())));
+
+	}
+
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/follow/implement/GithubUserReader.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/follow/implement/GithubUserReader.java
@@ -2,6 +2,7 @@ package com.moyoy.core.domain.follow.implement;
 
 import org.springframework.stereotype.Component;
 
+import com.moyoy.core.domain.user.implement.GithubUserProfileMeta;
 import com.moyoy.infra.github.feign.GithubProfileClient;
 import com.moyoy.infra.github.dto.GithubProfileResponse;
 
@@ -19,4 +20,12 @@ public class GithubUserReader {
 
 		return GithubFollowUser.from(githubProfileResponse);
 	}
+
+	public GithubUserProfileMeta fetchGithubUserProfile(Integer githubUserId, String accessToken) {
+
+		GithubProfileResponse githubProfileResponse = githubProfileClient.fetchUserProfile(accessToken, githubUserId);
+
+		return GithubUserProfileMeta.from(githubProfileResponse);
+	}
+
 }

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/user/business/UserProfileResult.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/user/business/UserProfileResult.java
@@ -1,0 +1,29 @@
+package com.moyoy.core.domain.user.business;
+
+import com.moyoy.core.domain.ranking.implement.Ranking;
+import com.moyoy.core.domain.user.implement.GithubUserProfileMeta;
+import com.moyoy.core.domain.user.implement.User;
+
+public record UserProfileResult(
+	Long userId,
+	String username,
+	long yearlyRankPoint,
+	String yearlyRankGrade,
+	String profileImgUrl,
+	int githubFollowerCount,
+	int githubFollowingCount
+) {
+
+	public static UserProfileResult from(User user, Ranking ranking,GithubUserProfileMeta githubUserProfileMeta) {
+
+		return new UserProfileResult(
+			user.getId(),
+			user.getUsername(),
+			ranking.getYearlyPoint(),
+			ranking.getGrade(),
+			user.getProfileImgUrl(),
+			githubUserProfileMeta.followerCount(),
+			githubUserProfileMeta.followingCount()
+		);
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/user/business/UserService.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/user/business/UserService.java
@@ -1,0 +1,36 @@
+package com.moyoy.core.domain.user.business;
+
+import org.springframework.stereotype.Service;
+
+import com.moyoy.core.common.helper.GithubOAuthTokenReader;
+import com.moyoy.core.domain.follow.implement.GithubUserReader;
+import com.moyoy.core.domain.ranking.implement.Ranking;
+import com.moyoy.core.domain.ranking.implement.RankingReader;
+import com.moyoy.core.domain.user.implement.GithubUserProfileMeta;
+import com.moyoy.core.domain.user.implement.User;
+import com.moyoy.core.domain.user.implement.UserReader;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserReader userReader;
+	private final RankingReader rankingReader;
+	private final GithubUserReader githubUserReader;
+	private final GithubOAuthTokenReader githubOAuthTokenReader;
+
+	public UserProfileResult getUserProfile(Long userId) {
+
+		User user = userReader.findById(userId).orElseThrow();
+		Ranking ranking = rankingReader.getRanking(user.getId());
+
+		Integer githubUserId = user.getGithubUserId();
+		String accessToken = githubOAuthTokenReader.getGithubAccessToken(userId);
+
+		GithubUserProfileMeta githubUserProfileMeta = githubUserReader.fetchGithubUserProfile(githubUserId, accessToken);
+
+		return UserProfileResult.from(user, ranking, githubUserProfileMeta);
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/user/implement/GithubUserProfileMeta.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/user/implement/GithubUserProfileMeta.java
@@ -1,0 +1,17 @@
+package com.moyoy.core.domain.user.implement;
+
+import com.moyoy.infra.github.dto.GithubProfileResponse;
+
+public record GithubUserProfileMeta(
+	int followerCount,
+	int followingCount
+) {
+
+
+	public static GithubUserProfileMeta from(GithubProfileResponse githubProfileResponse) {
+		return new GithubUserProfileMeta(
+			githubProfileResponse.followers(),
+			githubProfileResponse.following()
+		);
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/user/implement/UserReader.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/user/implement/UserReader.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.moyoy.core.db_access.domain.ranking.UserCountAndLastId;
 import com.moyoy.core.db_access.domain.user.UserRepository;
-
+import com.moyoy.core.domain.follow.implement.GithubUserReader;
 
 import lombok.RequiredArgsConstructor;
 


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #95 

## 🔎 PR 내용

<img width="447" height="194" alt="image" src="https://github.com/user-attachments/assets/7ff293ff-43b3-4f24-9916-1a6e3040c702" />


사용자 프로필 정보를 조회하는 기능을 새로 추가했습니다.

일단 프론트 쪽에서 써봐야 해서 단순 기능 구현만 미리 했고 추후 리팩토링 해 나가겠습니다~
