### PR TITLE
Setting: add Sonar Cloud

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,47 @@
+name: SonarCloud (Gradle)
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  sonar:
+    name: Code 품질 체크
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permisson for gradlew
+        run: chmod +x gradlew
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Build, Coverage, Sonar
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: >
+            clean build jacocoTestReport sonarqube
+            ${{ github.event_name == 'push' && '-Dsonar.qualitygate.wait=true' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -41,7 +41,8 @@ jobs:
         with:
           arguments: >
             clean build jacocoTestReport sonarqube
-            ${{ github.event_name == 'push' && '-Dsonar.qualitygate.wait=true' || '' }}
+            -Dsonar.qualitygate.wait=true
+            --info --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,8 +12,8 @@ permissions:
 
 jobs:
   sonar:
-    name: Code 품질 체크
     runs-on: ubuntu-latest
+    name: Code 품질 체크
 
     steps:
       - uses: actions/checkout@v4
@@ -23,11 +23,16 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: '21'
-          distribution: 'temurin'
 
-      - name: Grant execute permisson for gradlew
+      - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
@@ -36,13 +41,13 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
+
       - name: Build, Coverage, Sonar
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: >
-            clean build jacocoTestReport sonarqube
-            -Dsonar.qualitygate.wait=true
-            --info --stacktrace
+        run: |
+          ./gradlew clean build jacocoTestReport sonarqube \
+            -Dsonar.qualitygate.wait=true \
+            --info --stacktrace \
+            -Dorg.gradle.warning.mode=all
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id "org.sonarqube" version "6.2.0.5505"
     id 'org.springframework.boot' version '3.5.4' apply false
     id 'io.spring.dependency-management' version '1.1.7' apply false
     id 'com.diffplug.spotless' version "6.25.0" apply false
@@ -22,6 +23,7 @@ subprojects {
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'com.diffplug.spotless'
+    apply plugin: 'jacoco'
 
     repositories {
         mavenCentral()
@@ -44,8 +46,25 @@ subprojects {
 
     tasks.named('test') {
         useJUnitPlatform()
+        finalizedBy(tasks.named('jacocoTestReport'))
     }
 
+    jacoco {
+        toolVersion = "0.8.12"
+    }
+
+    tasks.named('jacocoTestReport', JacocoReport) {
+        dependsOn(tasks.named('test'))
+        reports {
+            xml.required = true
+            html.required = true
+        }
+
+        onlyIf {
+            file("$buildDir/jacoco/test.exec").exists() ||
+                    file("$buildDir/jacoco/test.exec.gz").exists()
+        }
+    }
 
     tasks.named('build') {
         dependsOn 'spotlessApply'
@@ -63,4 +82,16 @@ subprojects {
 
     bootJar.enabled = false
     jar.enabled = false
+}
+
+sonar {
+    properties {
+        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.projectKey", "Mo-yoy_Moyo-Backend"
+        property "sonar.organization", "mo-yoy"
+        property "sonar.coverage.jacoco.xmlReportPaths", "**/build/reports/jacoco/test/jacocoTestReport.xml"
+        property "sonar.sources", "."
+        property "sonar.sourceEncoding", "UTF-8"
+        property "sonar.coverage.exclusions", "**/*Application*.java, **/*Config.java, **/Q*.java"
+    }
 }


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #98 

## 🔎 PR 내용

### 개요
- SonarCloud를 이용한 코드 품질 검사 및 테스트 커버리지 측정 기능을 CI에 추가했습니다.
- PR 생성 및 develop 브랜치 푸시 시 자동으로 분석이 실행됩니다.

### 주요 변경 사항
1. GitHub Actions 워크플로우 `sonar.yml` 추가
   - JDK 21 환경 설정
   - gradlew 실행 권한 부여
   - SonarCloud 캐시 설정
   - Gradle 빌드 & JaCoCo 테스트 리포트 & Sonar 분석 실행
2. Gradle 설정 수정
   - `org.sonarqube` 플러그인 적용
   - JaCoCo 리포트(xml) 생성 경로 지정
   - SonarCloud 프로젝트/조직/인코딩 등 기본 속성 설정

### 동작 방식
- PR 생성 또는 develop 브랜치 푸시 → GitHub Actions 실행
- 빌드 & 테스트 → JaCoCo 커버리지 생성 → SonarCloud로 분석 결과 업로드
- 결과는 PR에 SonarCloud Bot이 댓글로 보고
- Quality Gate 기준을 통과하지 못하면 PR에 실패 사유가 표시됩니다.


### 참고 자료
[소나 클라우드 적용기](https://jojoldu.tistory.com/662)
[소나 클라우드 스프링 부트에 적용기](https://ji-soo708.tistory.com/25)