### PR TITLE
Refactor: restructure into multi-module

### DIFF
--- a/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/PrReviewController.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/PrReviewController.java
@@ -1,0 +1,117 @@
+package com.moyoy.api.presentation.v1.domain.pr_review;
+
+import com.moyoy.api.presentation.v1.domain.pr_review.response.PrReviewListResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.moyoy.api.support.annotation.LoginUserId;
+import com.moyoy.api.support.response.ApiResponse;
+import com.moyoy.core.domain.pr_review.business.PrReviewService;
+import com.moyoy.core.domain.pr_review.business.dto.*;
+import com.moyoy.core.domain.pr_review.business.dto.PrReviewContent;
+import com.moyoy.api.presentation.v1.domain.pr_review.request.*;
+import com.moyoy.api.presentation.v1.domain.pr_review.response.*;
+
+import jakarta.validation.Valid;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class PrReviewController {
+
+	private final PrReviewService prReviewService;
+
+	@GetMapping("/pr-review")
+	public ResponseEntity<ApiResponse<PrReviewListResponse>> prReviewList(
+		@Valid @ModelAttribute PrReviewListRequest prReviewListRequest) {
+
+		PrReviewSearchCriteria criteria = prReviewListRequest.toCriteria();
+
+		PrReviewListResult result = prReviewService.getPrReviewList(criteria);
+
+		PrReviewListResponse response = PrReviewListResponse.from(result);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@GetMapping("/pr-review/me")
+	public ResponseEntity<ApiResponse<PrReviewListResponse>> myPrReviewList(
+		@LoginUserId Long userId,
+		@Valid @ModelAttribute PrReviewListRequest prReviewListRequest) {
+
+		PrReviewSearchCriteria criteria = prReviewListRequest.toCriteria();
+
+		PrReviewListResult result = prReviewService.getMyPrReviewList(userId, criteria);
+
+		PrReviewListResponse response = PrReviewListResponse.from(result);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@GetMapping("/pr-review/{pr-reviewId}")
+	public ResponseEntity<ApiResponse<PrReviewDetailResponse>> prReviewDetail(
+		@LoginUserId Long userId,
+		@PathVariable("pr-reviewId") Long reviewId) {
+
+		PrReviewDetailResult result = prReviewService.getPrReviewDetail(reviewId, userId);
+
+		PrReviewDetailResponse response = PrReviewDetailResponse.from(result);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@PostMapping("/pr-review")
+	public ResponseEntity<ApiResponse<PrReviewRedirectResponse>> create(
+		@LoginUserId Long userId,
+		@RequestBody PrReviewFormRequest prReviewFormRequest) {
+
+		PrReviewContent content = prReviewFormRequest.toContent();
+
+		PrReviewCreateResult result = prReviewService.createPrReview(content, userId);
+
+		PrReviewRedirectResponse response = PrReviewRedirectResponse.from(result);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@GetMapping("/pr-review/{pr-reviewId}/form")
+	public ResponseEntity<ApiResponse<PrReviewUpdateFormResponse>> updateForm(
+		@LoginUserId Long userId,
+		@PathVariable("pr-reviewId") Long reviewId) {
+
+		PrReviewContent result = prReviewService.getPrReviewUpdateForm(reviewId, userId);
+
+		PrReviewUpdateFormResponse response = PrReviewUpdateFormResponse.from(result);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@PatchMapping("/pr-review/{pr-reviewId}")
+	public ResponseEntity<ApiResponse<PrReviewRedirectResponse>> update(
+		@LoginUserId Long userId,
+		@PathVariable("pr-reviewId") Long reviewId,
+		@RequestBody PrReviewFormRequest prReviewFormRequest) {
+
+		PrReviewContent content = prReviewFormRequest.toContent();
+
+		PrReviewUpdateResult result = prReviewService.updatePrReview(reviewId, content, userId);
+
+		PrReviewRedirectResponse response = PrReviewRedirectResponse.from(result);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@DeleteMapping("/pr-review/{pr-reviewId}")
+	public ResponseEntity<ApiResponse<Void>> delete(
+		@LoginUserId Long userId,
+		@PathVariable("pr-reviewId") Long reviewId) {
+
+		prReviewService.deletePrReview(reviewId, userId);
+
+		return ResponseEntity.ok(ApiResponse.noContent());
+	}
+}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/request/PrReviewFormRequest.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/request/PrReviewFormRequest.java
@@ -1,0 +1,20 @@
+package com.moyoy.api.presentation.v1.domain.pr_review.request;
+
+import com.moyoy.core.domain.pr_review.business.dto.PrReviewContent;
+
+public record PrReviewFormRequest(
+	String title,
+	String position,
+	String prUrl,
+	String content) {
+	public PrReviewFormRequest { // 글자수 제한이나 형식 제한 검증할 것인지.
+		title = (title == null) ? "" : title;
+		position = (position == null) ? "" : position;
+		prUrl = (prUrl == null) ? "" : prUrl;
+		content = (content == null) ? "" : content;
+	}
+
+	public PrReviewContent toContent() {
+		return new PrReviewContent(title, position, prUrl, content);
+	}
+}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/request/PrReviewListRequest.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/request/PrReviewListRequest.java
@@ -1,0 +1,23 @@
+package com.moyoy.api.presentation.v1.domain.pr_review.request;
+
+import com.moyoy.core.domain.pr_review.business.dto.PrReviewSearchCriteria;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PrReviewListRequest(
+	@NotBlank String status,
+	@NotBlank String order,
+	String position,
+	Integer page,
+	Integer size) {
+	public PrReviewListRequest {
+		status = (status == null) ? "open" : status;
+		order = (order == null) ? "createdAt,desc" : order;
+		page = (page == null) ? 0 : page;
+		size = (size == null) ? 10 : size;
+	}
+
+	public PrReviewSearchCriteria toCriteria() {
+		return new PrReviewSearchCriteria(status, order, position, page, size);
+	}
+}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/response/PrReviewDetailResponse.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/response/PrReviewDetailResponse.java
@@ -1,0 +1,32 @@
+package com.moyoy.api.presentation.v1.domain.pr_review.response;
+
+import com.moyoy.core.domain.pr_review.business.dto.PrReviewDetailResult;
+
+public record PrReviewDetailResponse(
+	String status,
+	boolean isWriter,
+	boolean isAdopted, // 채택은 스프린트2에서 추가 TODO
+	String profileImageUrl,
+	String username,
+	String position,
+	String title,
+	int hitCount,
+	String createdAt,
+	String content,
+	String prUrl) {
+
+	public static PrReviewDetailResponse from(PrReviewDetailResult result) {
+		return new PrReviewDetailResponse(
+			result.status(),
+			result.isWriter(),
+			result.isAdopted(),
+			result.profileImageUrl(),
+			result.username(),
+			result.position(),
+			result.title(),
+			result.hitCount(),
+			result.createdAt(),
+			result.content(),
+			result.prUrl());
+	}
+}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/response/PrReviewListResponse.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/response/PrReviewListResponse.java
@@ -1,0 +1,14 @@
+package com.moyoy.api.presentation.v1.domain.pr_review.response;
+
+import java.util.List;
+
+import com.moyoy.core.domain.pr_review.business.dto.PrReviewListResult;
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewSummary;
+
+public record PrReviewListResponse(
+	List<PrReviewSummary> prReviews,
+	boolean isLast) {
+	public static PrReviewListResponse from(PrReviewListResult result) {
+		return new PrReviewListResponse(result.prReviewList(), result.isLast());
+	}
+}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/response/PrReviewRedirectResponse.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/response/PrReviewRedirectResponse.java
@@ -1,0 +1,17 @@
+package com.moyoy.api.presentation.v1.domain.pr_review.response;
+
+import com.moyoy.core.domain.pr_review.business.dto.PrReviewCreateResult;
+import com.moyoy.core.domain.pr_review.business.dto.PrReviewUpdateResult;
+
+public record PrReviewRedirectResponse(
+	Long prReviewId) {
+	public static PrReviewRedirectResponse from(PrReviewCreateResult result) {
+		return new PrReviewRedirectResponse(
+			result.prReviewId());
+	}
+
+	public static PrReviewRedirectResponse from(PrReviewUpdateResult result) {
+		return new PrReviewRedirectResponse(
+			result.prReviewId());
+	}
+}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/response/PrReviewUpdateFormResponse.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/presentation/v1/domain/pr_review/response/PrReviewUpdateFormResponse.java
@@ -1,0 +1,18 @@
+package com.moyoy.api.presentation.v1.domain.pr_review.response;
+
+import com.moyoy.core.domain.pr_review.business.dto.PrReviewContent;
+
+public record PrReviewUpdateFormResponse(
+	String title,
+	String position,
+	String prUrl,
+	String content) {
+
+	public static PrReviewUpdateFormResponse from(PrReviewContent result) {
+		return new PrReviewUpdateFormResponse(
+			result.title(),
+			result.position(),
+			result.prUrl(),
+			result.content());
+	}
+}

--- a/Moyoy-Common/src/main/java/com/moyoy/common/exception/pr_review/PrReviewErrorCode.java
+++ b/Moyoy-Common/src/main/java/com/moyoy/common/exception/pr_review/PrReviewErrorCode.java
@@ -1,0 +1,28 @@
+package com.moyoy.common.exception.pr_review;
+
+import static com.moyoy.common.constant.MoyoConstants.FORBIDDEN;
+import static com.moyoy.common.constant.MoyoConstants.NOT_FOUND;
+
+import com.moyoy.common.exception.BaseErrorCode;
+import com.moyoy.common.exception.ErrorReason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PrReviewErrorCode implements BaseErrorCode {
+
+	PR_REVIEW_NOT_FOUND(NOT_FOUND, "PR_REVIEW_404_1", "존재하지 않는 PR 리뷰 요청글입니다."),
+	POSITION_TAG_NOT_FOUND(NOT_FOUND, "PR_REVIEW_404_2", "존재하지 않는 직군 태그입니다."),
+	PR_REVIEW_EDIT_FORBIDDEN(FORBIDDEN, "PR_REVIEW_403_1", "PR 리뷰 요청글을 수정할 권한이 없습니다."),
+	PR_REVIEW_DELETE_FORBIDDEN(FORBIDDEN, "PR_REVIEW_403_2", "PR 리뷰 요청글을 삭제할 권한이 없습니다.");
+
+	private final Integer status;
+	private final String code;
+	private final String message;
+
+	@Override
+	public ErrorReason getErrorReason() {
+		return new ErrorReason(status, code, message);
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewHitsJpaRepository.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewHitsJpaRepository.java
@@ -1,0 +1,13 @@
+package com.moyoy.core.db_access.domain.pr_review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.moyoy.core.domain.pr_review.implement.PrReview;
+import com.moyoy.core.domain.pr_review.implement.PrReviewHits;
+
+public interface PrReviewHitsJpaRepository extends JpaRepository<PrReviewHits, Long> {
+
+	boolean existsByPrReviewIdAndUserId(Long prReviewRequestId, Long userId);
+
+	void deleteByPrReview(PrReview prReview);
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewHitsRepository.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewHitsRepository.java
@@ -1,0 +1,13 @@
+package com.moyoy.core.db_access.domain.pr_review;
+
+import com.moyoy.core.domain.pr_review.implement.PrReview;
+import com.moyoy.core.domain.pr_review.implement.PrReviewHits;
+
+public interface PrReviewHitsRepository {
+
+	boolean existsByPrReviewIdAndUserId(Long prReviewRequestId, Long userId);
+
+	void deleteByPrReview(PrReview prReview);
+
+	void save(PrReviewHits prReviewHits);
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewHitsRepositoryImpl.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewHitsRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.moyoy.core.db_access.domain.pr_review;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Repository;
+
+import com.moyoy.core.domain.pr_review.implement.PrReview;
+import com.moyoy.core.domain.pr_review.implement.PrReviewHits;
+
+@Repository
+@RequiredArgsConstructor
+public class PrReviewHitsRepositoryImpl implements PrReviewHitsRepository {
+
+	private final PrReviewHitsJpaRepository prReviewHitsJpaRepository;
+
+	@Override
+	public boolean existsByPrReviewIdAndUserId(Long prReviewRequestId, Long userId) {
+		return prReviewHitsJpaRepository.existsByPrReviewIdAndUserId(prReviewRequestId, userId);
+	}
+
+	@Override
+	public void deleteByPrReview(PrReview prReview) {
+		prReviewHitsJpaRepository.deleteByPrReview(prReview);
+	}
+
+	@Override
+	public void save(PrReviewHits prReviewHits) {
+		prReviewHitsJpaRepository.save(prReviewHits);
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewJpaRepository.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewJpaRepository.java
@@ -1,0 +1,19 @@
+package com.moyoy.core.db_access.domain.pr_review;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.moyoy.core.domain.pr_review.implement.Position;
+import com.moyoy.core.domain.pr_review.implement.PrReview;
+
+public interface PrReviewJpaRepository extends JpaRepository<PrReview, Long> {
+
+	@Query("SELECT pr FROM PrReview pr WHERE pr.opened = :status AND (:position IS NULL OR pr.position = :position)")
+	Slice<PrReview> findAllByStatusAndPosition(Boolean status, Position position, Pageable pageable);
+
+	// 동등 조건 선행 쿼리 튜닝 ← user id 변경 적용 후 리팩토링 예정.
+	@Query("SELECT pr FROM PrReview pr WHERE pr.user.id = :userId AND pr.opened = :status AND (:position IS NULL OR pr.position = :position)")
+	Slice<PrReview> findAllByUserIdAndStatusAndPosition(Long userId, Boolean status, Position position, Pageable pageable);
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewRepository.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewRepository.java
@@ -1,0 +1,22 @@
+package com.moyoy.core.db_access.domain.pr_review;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import com.moyoy.core.domain.pr_review.implement.Position;
+import com.moyoy.core.domain.pr_review.implement.PrReview;
+
+public interface PrReviewRepository {
+
+	Slice<PrReview> findAllByStatusAndPosition(Boolean status, Position position, Pageable pageable);
+
+	Slice<PrReview> findAllByUserIdAndStatusAndPosition(Long userId, Boolean status, Position position, Pageable pageable);
+
+	Optional<PrReview> findById(Long reviewId);
+
+	PrReview save(PrReview review);
+
+	void delete(PrReview review);
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewRepositoryImpl.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/db_access/domain/pr_review/PrReviewRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.moyoy.core.db_access.domain.pr_review;
+
+import java.util.Optional;
+
+import com.moyoy.core.domain.pr_review.implement.Position;
+import com.moyoy.core.domain.pr_review.implement.PrReview;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PrReviewRepositoryImpl implements PrReviewRepository {
+
+	private final PrReviewJpaRepository prReviewJpaRepository;
+
+	@Override
+	public Slice<PrReview> findAllByStatusAndPosition(Boolean status, Position position, Pageable pageable) {
+		return prReviewJpaRepository.findAllByStatusAndPosition(status, position, pageable);
+	}
+
+	@Override
+	public Slice<PrReview> findAllByUserIdAndStatusAndPosition(Long userId, Boolean status, Position position, Pageable pageable) {
+		return prReviewJpaRepository.findAllByUserIdAndStatusAndPosition(userId, status, position, pageable);
+	}
+
+	@Override
+	public Optional<PrReview> findById(Long reviewId) {
+		return prReviewJpaRepository.findById(reviewId);
+	}
+
+	@Override
+	public PrReview save(PrReview review) {
+		return prReviewJpaRepository.save(review);
+	}
+
+	@Override
+	public void delete(PrReview review) {
+		prReviewJpaRepository.delete(review);
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/PrReviewService.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/PrReviewService.java
@@ -1,0 +1,104 @@
+package com.moyoy.core.domain.pr_review.business;
+
+import com.moyoy.common.exception.MoyoException;
+import com.moyoy.common.exception.pr_review.PrReviewErrorCode;
+import com.moyoy.common.exception.user.UserErrorCode;
+import com.moyoy.core.domain.pr_review.business.dto.*;
+import com.moyoy.core.domain.pr_review.implement.PrReview;
+import com.moyoy.core.domain.pr_review.implement.PrReviewHitsReader;
+import com.moyoy.core.domain.pr_review.implement.PrReviewReader;
+import com.moyoy.core.domain.pr_review.implement.PrReviewUpdater;
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewContentData;
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewCreateData;
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewDetail;
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewListData;
+import com.moyoy.core.domain.user.implement.User;
+import com.moyoy.core.domain.user.implement.UserReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PrReviewService {
+
+	private final PrReviewReader prReviewReader;
+	private final UserReader userReader;
+	private final PrReviewHitsReader prReviewHitsReader;
+	private final PrReviewUpdater prReviewUpdater;
+
+	public PrReviewListResult getPrReviewList(PrReviewSearchCriteria criteria) {
+
+		PrReviewListData data = prReviewReader.readListByCriteria(criteria.status(), criteria.order(), criteria.position(), criteria.page(), criteria.size());
+
+		return new PrReviewListResult(data.prReviews(), data.isLast());
+	}
+
+	public PrReviewListResult getMyPrReviewList(Long userId, PrReviewSearchCriteria criteria) {
+
+		PrReviewListData data = prReviewReader.readMyListByCriteria(userId, criteria.status(), criteria.order(), criteria.position(), criteria.page(), criteria.size());
+
+		return new PrReviewListResult(data.prReviews(), data.isLast());
+	}
+
+	public PrReviewDetailResult getPrReviewDetail(Long reviewId, Long userId) {
+		PrReviewDetail data = prReviewReader.readPrReviewDetail(reviewId, userId);
+
+		// 2. 조회수 증가 관리 (IP 기반으로 중복 방지 공부 후 적용)
+		// TODO
+
+		return PrReviewDetailResult.from(data);
+	}
+
+	public PrReviewCreateResult createPrReview(PrReviewContent content, Long userId) {
+
+		User writer = userReader.findById(userId)
+			.orElseThrow(() -> new MoyoException(UserErrorCode.USER_NOT_FOUND));
+
+		PrReview prReview = PrReview.from(content.title(), content.position(), content.prUrl(), content.content(), writer);
+
+		PrReviewCreateData data = prReviewUpdater.create(prReview);
+
+		return new PrReviewCreateResult(data.prReviewId());
+	}
+
+	public PrReviewContent getPrReviewUpdateForm(Long reviewId, Long userId) {
+
+		PrReviewContentData data = prReviewReader.readPrReviewContent(reviewId, userId);
+
+		if (!data.isWriter()) {
+			throw new MoyoException(PrReviewErrorCode.PR_REVIEW_EDIT_FORBIDDEN);
+		}
+
+		return PrReviewContent.from(data);
+	}
+
+	@Transactional
+	public PrReviewUpdateResult updatePrReview(Long reviewId, PrReviewContent content, Long userId) {
+
+		PrReview prReview = prReviewReader.readPrReview(reviewId);
+
+		if (!prReview.getUser().getId().equals(userId)) {
+			throw new MoyoException(PrReviewErrorCode.PR_REVIEW_EDIT_FORBIDDEN);
+		}
+
+		prReview.updateDetail(content.title(), content.position(), content.prUrl(), content.content());
+
+		return new PrReviewUpdateResult(prReview.getId());
+	}
+
+	@Transactional
+	public void deletePrReview(Long reviewId, Long userId) {
+
+		PrReview prReview = prReviewReader.readPrReview(reviewId);
+
+		if (!prReview.getUser().getId().equals(userId)) {
+			throw new MoyoException(PrReviewErrorCode.PR_REVIEW_DELETE_FORBIDDEN);
+		}
+
+		// 3. 조회수 테이블 따로 둘 경우, 해당 요청글의 조회수 데이터 삭제 (아직 방식 고민 중)
+		// TODO
+
+		prReviewUpdater.delete(prReview);
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewContent.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewContent.java
@@ -1,0 +1,18 @@
+package com.moyoy.core.domain.pr_review.business.dto;
+
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewContentData;
+
+public record PrReviewContent(
+	String title,
+	String position,
+	String prUrl,
+	String content) {
+
+	public static PrReviewContent from(PrReviewContentData data) {
+		return new PrReviewContent(
+			data.title(),
+			data.position(),
+			data.prUrl(),
+			data.content());
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewCreateResult.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewCreateResult.java
@@ -1,0 +1,5 @@
+package com.moyoy.core.domain.pr_review.business.dto;
+
+public record PrReviewCreateResult(
+	Long prReviewId) {
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewDetailResult.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewDetailResult.java
@@ -1,0 +1,31 @@
+package com.moyoy.core.domain.pr_review.business.dto;
+
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewDetail;
+
+public record PrReviewDetailResult(
+	String status,
+	boolean isWriter,
+	boolean isAdopted, // 채택은 스프린트2에서 추가 TODO
+	String profileImageUrl,
+	String username,
+	String position,
+	String title,
+	int hitCount,
+	String createdAt,
+	String content,
+	String prUrl) {
+	public static PrReviewDetailResult from(PrReviewDetail pr) {
+		return new PrReviewDetailResult(
+			pr.status(),
+			pr.isWriter(),
+			pr.isAdopted(),
+			pr.profileImageUrl(),
+			pr.username(),
+			pr.position(),
+			pr.title(),
+			pr.hitCount(),
+			pr.createdAt(),
+			pr.content(),
+			pr.prUrl());
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewListResult.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewListResult.java
@@ -1,0 +1,10 @@
+package com.moyoy.core.domain.pr_review.business.dto;
+
+import java.util.List;
+
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewSummary;
+
+public record PrReviewListResult(
+	List<PrReviewSummary> prReviewList,
+	boolean isLast) {
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewSearchCriteria.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewSearchCriteria.java
@@ -1,0 +1,14 @@
+package com.moyoy.core.domain.pr_review.business.dto;
+
+import com.moyoy.core.domain.pr_review.implement.dto.SearchCriteria;
+
+public record PrReviewSearchCriteria(
+	String status,
+	String order,
+	String position,
+	int page,
+	int size) {
+	public SearchCriteria toCriteria() {
+		return new SearchCriteria(status, order, position, page, size);
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewUpdateResult.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/business/dto/PrReviewUpdateResult.java
@@ -1,0 +1,5 @@
+package com.moyoy.core.domain.pr_review.business.dto;
+
+public record PrReviewUpdateResult(
+	Long prReviewId) {
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/Position.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/Position.java
@@ -1,0 +1,32 @@
+package com.moyoy.core.domain.pr_review.implement;
+
+import java.util.Arrays;
+
+import com.moyoy.common.exception.MoyoException;
+import com.moyoy.common.exception.pr_review.PrReviewErrorCode;
+
+public enum Position {
+	BACKEND("백엔드"),
+	FRONTEND("프론트엔드"),
+	IOS("iOS"),
+	ANDROID("안드로이드"),
+	DEVOPS("DevOps"),
+	OTHER("기타");
+
+	private final String value;
+
+	Position(String value) {
+		this.value = value;
+	}
+
+	public static Position from(String value) {
+
+		if (value == null)
+			return null; // 직군 태그 null 허용할 건지, 다음 회의 안건 등록. FIXME
+
+		return Arrays.stream(Position.values())
+			.filter(position -> position.name().equalsIgnoreCase(value) || position.value.equals(value))
+			.findFirst()
+			.orElseThrow(() -> new MoyoException(PrReviewErrorCode.POSITION_TAG_NOT_FOUND));
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/PrReview.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/PrReview.java
@@ -1,0 +1,95 @@
+package com.moyoy.core.domain.pr_review.implement;
+
+import com.moyoy.core.common.entity.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.moyoy.core.domain.user.implement.User;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "pr_review")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PrReview extends BaseTimeEntity {
+
+	@Id
+	@Column(name = "pr_review_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Lob
+	@Column(nullable = false)
+	@JdbcTypeCode(SqlTypes.LONGVARCHAR)
+	private String content;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Column(nullable = false)
+	private String prUrl;
+
+	@Column(nullable = true)
+	@Enumerated(EnumType.STRING)
+	private Position position;
+
+	@Column(nullable = false)
+	private int hitCount;
+
+	@Column(nullable = false)
+	private boolean opened; // open, closed 여부.
+
+	@Column(nullable = false)
+	private boolean adopted;
+
+	@Builder
+	public PrReview(String title, String content, User user, String prUrl, Position position, int hitCount, boolean opened, boolean adopted) {
+		this.title = title;
+		this.content = content;
+		this.user = user;
+		this.prUrl = prUrl;
+		this.position = position;
+		this.hitCount = hitCount;
+		this.opened = opened;
+		this.adopted = adopted;
+	}
+
+	public static PrReview from(
+		String title,
+		String position,
+		String prUrl,
+		String content,
+		User user) {
+		return PrReview.builder()
+			.title(title)
+			.content(content)
+			.user(user)
+			.prUrl(prUrl)
+			.position(Position.from(position))
+			.hitCount(0)
+			.opened(true)
+			.adopted(false)
+			.build();
+	}
+
+	public void increaseHitCount() {
+		this.hitCount++;
+	}
+
+	public void updateDetail(String title, String position, String prUrl, String content) {
+		this.title = title;
+		this.content = content;
+		this.prUrl = prUrl;
+		this.position = Position.from(position);
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/PrReviewHits.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/PrReviewHits.java
@@ -1,0 +1,39 @@
+package com.moyoy.core.domain.pr_review.implement;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.moyoy.core.common.entity.BaseTimeEntity;
+import com.moyoy.core.domain.user.implement.User;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "pr_review_hits", uniqueConstraints = {
+	@UniqueConstraint(name = "unique_user_pr", columnNames = {"user_id", "pr_review_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PrReviewHits extends BaseTimeEntity {
+
+	// TODO: 조회수 부분은 기획 변경으로 로직이 많이 바뀔 것임.
+	@Id
+	@Column(name = "pr_review_hits_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "pr_review_id", nullable = false)
+	private PrReview prReview;
+
+	public PrReviewHits(User user, PrReview prReview) {
+		this.user = user;
+		this.prReview = prReview;
+	}
+
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/PrReviewHitsReader.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/PrReviewHitsReader.java
@@ -1,0 +1,6 @@
+package com.moyoy.core.domain.pr_review.implement;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PrReviewHitsReader {}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/PrReviewReader.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/PrReviewReader.java
@@ -1,0 +1,99 @@
+package com.moyoy.core.domain.pr_review.implement;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import com.moyoy.common.exception.CommonErrorCode;
+import com.moyoy.common.exception.MoyoException;
+import com.moyoy.core.db_access.domain.pr_review.PrReviewRepository;
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewContentData;
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewDetail;
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewListData;
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewSummary;
+
+@Component
+@RequiredArgsConstructor
+public class PrReviewReader {
+
+	private final PrReviewRepository prReviewRepository;
+
+	public PrReviewListData readListByCriteria(String status, String order, String position, int page, int size) {
+
+		Sort sort = sortByOrder(order);
+
+		Pageable pageable = PageRequest.of(page, size, sort);
+
+		Slice<PrReview> slice = prReviewRepository.findAllByStatusAndPosition(
+			"open".equalsIgnoreCase(status),
+			Position.from(position),
+			pageable);
+
+		List<PrReviewSummary> prReviews = slice.getContent().stream()
+			.map(PrReviewSummary::from)
+			.toList();
+
+		return new PrReviewListData(prReviews, slice.hasNext());
+	}
+
+	public PrReviewListData readMyListByCriteria(Long userId, String status, String order, String position, int page, int size) {
+
+		Sort sort = sortByOrder(order);
+
+		Pageable pageable = PageRequest.of(page, size, sort);
+
+		Slice<PrReview> slice = prReviewRepository.findAllByUserIdAndStatusAndPosition(
+			userId,
+			"open".equalsIgnoreCase(status),
+			Position.from(position),
+			pageable);
+
+		List<PrReviewSummary> prReviews = slice.getContent().stream()
+			.map(PrReviewSummary::from)
+			.toList();
+
+		return new PrReviewListData(prReviews, slice.hasNext());
+	}
+
+	public PrReviewDetail readPrReviewDetail(Long reviewId, Long userId) {
+
+		// 유효하지 않은 reviewId 검증.
+		PrReview prReview = prReviewRepository.findById(reviewId)
+			.orElseThrow(() -> new MoyoException(CommonErrorCode.INVALID_PARAM));
+
+		return PrReviewDetail.from(prReview, userId);
+	}
+
+	public PrReviewContentData readPrReviewContent(Long reviewId, Long userId) {
+
+		PrReview prReview = prReviewRepository.findById(reviewId)
+			.orElseThrow(() -> new MoyoException(CommonErrorCode.INVALID_PARAM));
+
+		return PrReviewContentData.from(prReview, userId);
+	}
+
+	public PrReview readPrReview(Long reviewId) {
+		return prReviewRepository.findById(reviewId)
+			.orElseThrow(() -> new MoyoException(CommonErrorCode.INVALID_PARAM));
+	}
+
+	public Sort sortByOrder(String order) {
+		String[] tokens = order.split(",");
+		if (tokens.length != 2) {
+			throw new MoyoException(CommonErrorCode.INVALID_PARAM);
+		}
+
+		try {
+			Sort.Direction direction = Sort.Direction.fromString(tokens[1].toUpperCase());
+			return Sort.by(direction, tokens[0]); // 예시: Sort.by(Sort.Direction.DESC, "createdAt").
+		} catch (IllegalArgumentException e) {
+			throw new MoyoException(CommonErrorCode.PARAM_TYPE_MISMATCH);
+		}
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/PrReviewUpdater.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/PrReviewUpdater.java
@@ -1,0 +1,28 @@
+package com.moyoy.core.domain.pr_review.implement;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+import com.moyoy.core.db_access.domain.pr_review.PrReviewRepository;
+import com.moyoy.core.domain.pr_review.implement.dto.PrReviewCreateData;
+
+import jakarta.transaction.Transactional;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class PrReviewUpdater {
+
+	private final PrReviewRepository prReviewRepository;
+
+	public PrReviewCreateData create(PrReview prReview) {
+		PrReview savedPr = prReviewRepository.save(prReview);
+
+		return new PrReviewCreateData(savedPr.getId());
+	}
+
+	public void delete(PrReview prReview) {
+		prReviewRepository.delete(prReview);
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/PrReviewContentData.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/PrReviewContentData.java
@@ -1,0 +1,19 @@
+package com.moyoy.core.domain.pr_review.implement.dto;
+
+import com.moyoy.core.domain.pr_review.implement.PrReview;
+
+public record PrReviewContentData(
+	String title,
+	String position,
+	String prUrl,
+	String content,
+	boolean isWriter) {
+	public static PrReviewContentData from(PrReview prReview, Long userId) {
+		return new PrReviewContentData(
+			prReview.getTitle(),
+			prReview.getPosition().toString(),
+			prReview.getPrUrl(),
+			prReview.getContent(),
+			prReview.getUser().getId().equals(userId));
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/PrReviewCreateData.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/PrReviewCreateData.java
@@ -1,0 +1,5 @@
+package com.moyoy.core.domain.pr_review.implement.dto;
+
+public record PrReviewCreateData(
+	Long prReviewId) {
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/PrReviewDetail.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/PrReviewDetail.java
@@ -1,0 +1,31 @@
+package com.moyoy.core.domain.pr_review.implement.dto;
+
+import com.moyoy.core.domain.pr_review.implement.PrReview;
+
+public record PrReviewDetail(
+	String status,
+	boolean isWriter,
+	boolean isAdopted, // 채택은 스프린트2에서 추가 TODO
+	String profileImageUrl,
+	String username,
+	String position,
+	String title,
+	int hitCount,
+	String createdAt,
+	String content,
+	String prUrl) {
+	public static PrReviewDetail from(PrReview pr, Long userId) {
+		return new PrReviewDetail(
+			pr.isOpened() ? "open" : "closed",
+			pr.getUser().getId().equals(userId),
+			pr.isAdopted(),
+			pr.getUser().getProfileImgUrl(),
+			pr.getUser().getUsername(),
+			pr.getPosition().toString(),
+			pr.getTitle(),
+			pr.getHitCount(),
+			pr.getCreatedAt().toString(),
+			pr.getContent(),
+			pr.getPrUrl());
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/PrReviewListData.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/PrReviewListData.java
@@ -1,0 +1,8 @@
+package com.moyoy.core.domain.pr_review.implement.dto;
+
+import java.util.List;
+
+public record PrReviewListData(
+	List<PrReviewSummary> prReviews,
+	boolean isLast) {
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/PrReviewSummary.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/PrReviewSummary.java
@@ -1,0 +1,23 @@
+package com.moyoy.core.domain.pr_review.implement.dto;
+
+import static com.moyoy.common.util.TimeSinceFormatter.*;
+
+import com.moyoy.core.domain.pr_review.implement.PrReview;
+
+public record PrReviewSummary(
+	String profileImageUrl,
+	String username,
+	String position,
+	String title,
+	String since,
+	int hitCount) {
+	public static PrReviewSummary from(PrReview pr) {
+		return new PrReviewSummary(
+			pr.getUser().getProfileImgUrl(),
+			pr.getUser().getUsername(),
+			pr.getPosition().toString(),
+			pr.getTitle(),
+			formatTimeSince(pr.getCreatedAt()),
+			pr.getHitCount());
+	}
+}

--- a/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/SearchCriteria.java
+++ b/Moyoy-Core/src/main/java/com/moyoy/core/domain/pr_review/implement/dto/SearchCriteria.java
@@ -1,0 +1,9 @@
+package com.moyoy.core.domain.pr_review.implement.dto;
+
+public record SearchCriteria(
+	String status,
+	String order,
+	String position,
+	int page,
+	int size) {
+}


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #97

## ☑️ 완료 태스크
- [x] pr_review api
- [x] pr_review core

<br />

## 🔎 PR 내용

멀티 모듈로 전환하면서, 기존에 작업했던 pr_review 역시 api 모듈과 core 모듈로 나눴습니다.
디렉토리만 바꾼 수준이라서 기능이 달라지진 않았고,
postman으로 테스트 해본 결과 이상 없었습니다.

아직 모듈 구조 자체는 @seungryul99 형이 참고해서 잡아둔 대로 잡혀있는 상태고,
business 레이어의 위치나 data_access의 위치에 대해서는 생각하는 바가 조금 다르긴 한데 계속 작업하면서 조정해나가기로 했습니다.

<br />

## 📷 스크린샷

<!-- 팀원들이 이해할 수 있게 구현한 화면을 보여주세요 -->