### PR TITLE
fix: modify Cache Sync Error

### DIFF
--- a/Moyoy-Api/src/main/java/com/moyoy/api/github_follow/application/GithubFollowService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/github_follow/application/GithubFollowService.java
@@ -72,8 +72,12 @@ public class GithubFollowService {
 
 			boolean canRefresh = followSnapshot.get().canRefresh();
 
-			if (!canRefresh)
+			if (!canRefresh){
+				log.warn("팔로우 캐시 5분 내 강제 갱신 시도 발생 | userId={}", currentUserId);
 				throw new GithubFollowSnapshotCoolDownNotExpiredException();
+			}
+
+			followSnapshotCacheManager.delete(currentUserId);
 		}
 
 		User user = userRepository.findById(currentUserId).orElseThrow(UserNotFoundException::new);

--- a/Moyoy-Api/src/main/java/com/moyoy/api/github_follow/application/GithubFollowService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/github_follow/application/GithubFollowService.java
@@ -72,7 +72,7 @@ public class GithubFollowService {
 
 			boolean canRefresh = followSnapshot.get().canRefresh();
 
-			if (!canRefresh){
+			if (!canRefresh) {
 				log.warn("팔로우 캐시 5분 내 강제 갱신 시도 발생 | userId={}", currentUserId);
 				throw new GithubFollowSnapshotCoolDownNotExpiredException();
 			}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/github_follow/presentation/response/GithubFollowDetectResponse.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/github_follow/presentation/response/GithubFollowDetectResponse.java
@@ -1,18 +1,17 @@
 package com.moyoy.api.github_follow.presentation.response;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.moyoy.api.github_follow.application.response.GithubFollowDetectionResult;
 
 import com.moyoy.domain.follow.GithubUser;
 
-import com.moyoy.common.util.TimeSinceFormatter;
-
 public record GithubFollowDetectResponse(
 	List<GithubFollowUserDto> userList,
 	boolean lastPage,
 	int totalUserCount,
-	String lastSyncAt) {
+	LocalDateTime lastSyncAt) {
 
 	public record GithubFollowUserDto(
 		Integer githubUserId,
@@ -38,6 +37,6 @@ public record GithubFollowDetectResponse(
 			userDtoList,
 			followDetectionResult.users().isLast(),
 			followDetectionResult.totalFollowUserCount(),
-			TimeSinceFormatter.formatTimeSince(followDetectionResult.lastSyncAt()));
+			followDetectionResult.lastSyncAt());
 	}
 }

--- a/Moyoy-Api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/Moyoy-Api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -179,7 +179,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-users-me-followings-refresh492296449"
+                $ref: "#/components/schemas/api-v1-users-me-followings-detectType492296449"
               examples:
                 FOLLOW_400_1:
                   value: "{\"status\":400,\"code\":\"FOLLOW_400_1\",\"message\":\"\
@@ -189,7 +189,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-users-me-followings-refresh63148865"
+                $ref: "#/components/schemas/api-v1-users-me-followings-detectType63148865"
               examples:
                 맞팔탐지기 조회를 위한 데이터 강제 갱신 요청:
                   value: "{\"status\":202,\"code\":\"ACCEPTED\",\"message\":null,\"\
@@ -234,7 +234,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-users-me-followings-refresh492296449"
+                $ref: "#/components/schemas/api-v1-users-me-followings-detectType492296449"
               examples:
                 GITHUB_400_1:
                   value: "{\"status\":400,\"code\":\"GITHUB_400_1\",\"message\":\"\
@@ -244,21 +244,21 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-users-me-followings-detectType1462305756"
+                $ref: "#/components/schemas/api-v1-users-me-followings-detectType220603757"
               examples:
                 맞팔탐지기 조회 성공:
                   value: "{\"status\":200,\"code\":\"OK\",\"message\":null,\"data\"\
                     :{\"userList\":[{\"githubUserId\":12345,\"username\":\"username1\"\
                     ,\"profileImgUrl\":\"http://profile.image/1\"},{\"githubUserId\"\
                     :67890,\"username\":\"username2\",\"profileImgUrl\":\"http://profile.image/2\"\
-                    }],\"lastPage\":true,\"totalUserCount\":2,\"lastSyncAt\":\"5분\
-                    \ 전\"}}"
+                    }],\"lastPage\":true,\"totalUserCount\":2,\"lastSyncAt\":\"2025-08-28T16:16:10.944301811\"\
+                    }}"
         "202":
           description: "202"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-users-me-followings-refresh63148865"
+                $ref: "#/components/schemas/api-v1-users-me-followings-detectType63148865"
               examples:
                 맞팔탐지기 조회를 위한 데이터 수집 요청 완료:
                   value: "{\"status\":202,\"code\":\"ACCEPTED\",\"message\":null,\"\
@@ -267,7 +267,7 @@ paths:
       - bearerAuthJWT: []
 components:
   schemas:
-    api-v1-users-me-followings-refresh63148865:
+    api-v1-users-me-followings-detectType63148865:
       required:
       - code
       - message
@@ -296,56 +296,7 @@ components:
         status:
           type: number
           description: ❌ 응답 상태 코드
-    api-v1-users-me-followings-detectType1462305756:
-      required:
-      - code
-      - message
-      - status
-      type: object
-      properties:
-        code:
-          type: string
-          description: 🔢 응답 코드
-        data:
-          required:
-          - lastPage
-          - lastSyncAt
-          - totalUserCount
-          - userList
-          type: object
-          properties:
-            totalUserCount:
-              type: number
-              description: 📊 총 사용자 수
-            userList:
-              type: array
-              description: 👤 탐지된 사용자 목록
-              items:
-                required:
-                - githubUserId
-                - profileImgUrl
-                - username
-                type: object
-                properties:
-                  profileImgUrl:
-                    type: string
-                    description: 사용자 프로필 이미지 URL
-                  githubUserId:
-                    type: number
-                    description: 사용자 Github ID
-                  username:
-                    type: string
-                    description: 사용자 이름
-            lastPage:
-              type: boolean
-              description: 📌 마지막 페이지 여부
-            lastSyncAt:
-              type: string
-              description: ⏱ 마지막 싱크 시간 (x 분전)
-        status:
-          type: number
-          description: ✅ 응답 상태 코드
-    api-v1-users-me-followings-refresh492296449:
+    api-v1-users-me-followings-detectType492296449:
       required:
       - code
       - message
@@ -407,6 +358,55 @@ components:
             username:
               type: string
               description: 🙋 사용자 이름
+        status:
+          type: number
+          description: ✅ 응답 상태 코드
+    api-v1-users-me-followings-detectType220603757:
+      required:
+      - code
+      - message
+      - status
+      type: object
+      properties:
+        code:
+          type: string
+          description: 🔢 응답 코드
+        data:
+          required:
+          - lastPage
+          - lastSyncAt
+          - totalUserCount
+          - userList
+          type: object
+          properties:
+            totalUserCount:
+              type: number
+              description: 📊 총 사용자 수
+            userList:
+              type: array
+              description: 👤 탐지된 사용자 목록
+              items:
+                required:
+                - githubUserId
+                - profileImgUrl
+                - username
+                type: object
+                properties:
+                  profileImgUrl:
+                    type: string
+                    description: 사용자 프로필 이미지 URL
+                  githubUserId:
+                    type: number
+                    description: 사용자 Github ID
+                  username:
+                    type: string
+                    description: 사용자 이름
+            lastPage:
+              type: boolean
+              description: 📌 마지막 페이지 여부
+            lastSyncAt:
+              type: string
+              description: ⏱ 마지막 싱크 시간 타임 스탬프
         status:
           type: number
           description: ✅ 응답 상태 코드

--- a/Moyoy-Api/src/test/java/com/moyoy/api/github_follow/presentation/GithubFollowControllerTest.java
+++ b/Moyoy-Api/src/test/java/com/moyoy/api/github_follow/presentation/GithubFollowControllerTest.java
@@ -70,7 +70,7 @@ class GithubFollowControllerTest {
 
 	@WithMockMoyoyUser
 	@Test
-	void 맞팔탐지기_성공_문서화_200_OK() throws Exception {
+	void 맞팔탐지기_조회_성공_문서화_200_OK() throws Exception {
 
 		// given
 		GithubUser user1 = new GithubUser(12345, "username1", "http://profile.image/1");
@@ -78,7 +78,7 @@ class GithubFollowControllerTest {
 
 		List<GithubUser> userList = List.of(user1, user2);
 		int totalUserCount = userList.size();
-		LocalDateTime createdAt = LocalDateTime.now().minusMinutes(5);
+		LocalDateTime createdAt = LocalDateTime.of(2025, 8, 28, 16, 16, 10, 944301811);
 
 		SliceResult<GithubUser> userSlice = SliceResult.of(userList, false);
 
@@ -95,6 +95,7 @@ class GithubFollowControllerTest {
 			.andExpect(jsonPath("$.data.userList").isArray())
 			.andExpect(jsonPath("$.data.totalUserCount").value(2))
 			.andExpect(jsonPath("$.data.lastPage").value(true))
+			.andExpect(jsonPath("$.data.lastSyncAt").exists())
 
 			// REST Docs
 			.andDo(document("맞팔탐지기 조회 성공",
@@ -117,14 +118,14 @@ class GithubFollowControllerTest {
 						fieldWithPath("data.userList[].profileImgUrl").description("사용자 프로필 이미지 URL"),
 						fieldWithPath("data.totalUserCount").description("📊 총 사용자 수"),
 						fieldWithPath("data.lastPage").description("📌 마지막 페이지 여부"),
-						fieldWithPath("data.lastSyncAt").description("⏱ 마지막 싱크 시간 (x 분전)"))
+						fieldWithPath("data.lastSyncAt").description("⏱ 마지막 싱크 시간 타임 스탬프"))
 					.build())));
 
 	}
 
 	@WithMockMoyoyUser
 	@Test
-	void 맞팔탐지기_성공_문서화_202_ACCEPTED() throws Exception {
+	void 맞팔탐지기_조회_성공_문서화_202_ACCEPTED() throws Exception {
 
 		// given
 		Optional<GithubFollowDetectionResult> result = Optional.empty();

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/redis/follow/GithubFollowSnapshotCacheManager.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/redis/follow/GithubFollowSnapshotCacheManager.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.stereotype.Component;
 
@@ -28,5 +29,11 @@ public class GithubFollowSnapshotCacheManager {
 	public GithubFollowSnapshot save(Long userId, GithubFollowSnapshot githubFollowRelationSnapshot) {
 		return githubFollowRelationSnapshot;
 	}
+
+	@CacheEvict(cacheNames = "followSnapshot", key = "#userId")
+	public void delete(Long userId) {
+
+	}
+
 
 }


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #117 

<br />

## 🔎 PR 내용

맞팔 탐지기 강제갱신 API 호출 시 

서버 내부에서 캐시 갱신 작업이 제출 되는데

강제갱신 -> 조회를 연달아 수행할 경우

이전 캐시 갱신전 데이터가 그대로 조회되는 문제를 수정했습니다.

또한 클라이언트에서 갱신시간 교차검증, 활용등을 위해서 00분전 -> TimeStamp로 API 스펙을 변경했습니다.



### AS-IS

새 데이터를 받아온 시점에 캐시 덮어쓰기


### TO-BE

기존 캐시 삭제후 새 데이터 저장 