### PR TITLE
setting: environment setup for circuit breaker

### DIFF
--- a/Moyoy-Api/src/main/resources/application.yml
+++ b/Moyoy-Api/src/main/resources/application.yml
@@ -29,3 +29,5 @@ spring:
 
 logging:
   config: classpath:logback/logback-${spring.profiles.active:local}.xml
+
+

--- a/Moyoy-Infra/build.gradle
+++ b/Moyoy-Infra/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.43.0'
+
+    // resilience4j
+    implementation "org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j"
 }
 
 jar.enabled = true

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/external/github/follow/GithubFollowClientImpl.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/external/github/follow/GithubFollowClientImpl.java
@@ -8,6 +8,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,6 +38,7 @@ public class GithubFollowClientImpl implements GithubFollowClient {
 	private final ObjectMapper objectMapper;
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "followFetchFallBack")
 	public List<GithubUser> fetchFollowings(Long userId, Integer githubUserId) {
 
 		String accessToken = githubOAuthTokenReader.getGithubAccessToken(userId);
@@ -68,6 +71,7 @@ public class GithubFollowClientImpl implements GithubFollowClient {
 	}
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "followFetchFallBack")
 	public List<GithubUser> fetchFollowers(Long userId, Integer githubUserId) {
 
 		String accessToken = githubOAuthTokenReader.getGithubAccessToken(userId);
@@ -100,6 +104,7 @@ public class GithubFollowClientImpl implements GithubFollowClient {
 	}
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "followCommandFallback")
 	public void follow(Long currentUserId, Integer targetUserGithubId) {
 
 		String accessToken = githubOAuthTokenReader.getGithubAccessToken(currentUserId);
@@ -118,6 +123,7 @@ public class GithubFollowClientImpl implements GithubFollowClient {
 	}
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "followCommandFallback")
 	public void unFollow(Long currentUserId, Integer targetUserGithubId) {
 
 		String accessToken = githubOAuthTokenReader.getGithubAccessToken(currentUserId);
@@ -134,6 +140,21 @@ public class GithubFollowClientImpl implements GithubFollowClient {
 			log.warn("깃허브 언팔로우 요청 실패 | currentUserId : {}, targetUserId : {}, responseStatus : {}", currentUserId, targetUserGithubId, responseStatus);
 			throw new RuntimeException("깃허브 언팔로우 요청 처리 실패"); /// TODO 추후 처리
 		}
+	}
+
+
+	private void followFetchFallBack(Long userId, Integer githubUserId, Throwable throwable) {
+		if(throwable instanceof CallNotPermittedException){
+
+		}
+		/// TODO : 에러코드 회의 후 처리
+	}
+
+	private void followCommandFallback(Long userId, Integer githubUserId, Throwable throwable) {
+		if(throwable instanceof CallNotPermittedException){
+
+		}
+		/// TODO : 에러코드 회의 후 처리
 	}
 
 	private int getLimitRemaining(Response response) {

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/external/github/repo/GithubRepoClientImpl.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/external/github/repo/GithubRepoClientImpl.java
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import feign.Response;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,6 +29,7 @@ public class GithubRepoClientImpl implements GithubRepoClient{
 	private final ObjectMapper objectMapper;
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "repoFetchFallBack")
 	public List<GithubRepoResponse> fetchReposCreatedThisYear(String accessToken) {
 
 		final String affiliation = "owner,organization_member";
@@ -59,12 +62,14 @@ public class GithubRepoClientImpl implements GithubRepoClient{
 	}
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "repoFetchFallBack")
 	public List<GithubRepoContributorsResponse> fetchRepoContributors(String accessToken, String repoFullName) {
 
 		return githubRepoFeignClient.fetchRepoContributors(repoFullName, accessToken);
 	}
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "statFetchFallBack")
 	public List<GithubRepoCommitStatsResponse> fetchRepoContributorStats(String repoFullName, String accessToken) {
 
 		int maxTryCount = 10;
@@ -98,6 +103,19 @@ public class GithubRepoClientImpl implements GithubRepoClient{
 		return parseContributorStatsResponse(response, repoFullName);
 	}
 
+	private void repoFetchFallBack(Long userId, Integer githubUserId, Throwable throwable) {
+		if(throwable instanceof CallNotPermittedException){
+
+		}
+		/// TODO : 에러코드 회의 후 처리
+	}
+
+	private void statFetchFallBack(Long userId, Integer githubUserId, Throwable throwable) {
+		if(throwable instanceof CallNotPermittedException){
+
+		}
+		/// TODO : 에러코드 회의 후 처리
+	}
 
 	private List<GithubRepoCommitStatsResponse> parseContributorStatsResponse(Response response, String repoFullName) {
 		try {

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/external/github/user/GithubUserClientImpl.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/external/github/user/GithubUserClientImpl.java
@@ -1,5 +1,7 @@
 package com.moyoy.infra.external.github.user;
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,6 +20,7 @@ public class GithubUserClientImpl implements GithubUserClient {
 	private final GithubOAuthTokenReader githubOAuthTokenReader;
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "userFetchFallBack")
 	public GithubUserResponse fetchUser(Long userId, Integer githubUserId) {
 
 		String accessToken = githubOAuthTokenReader.getGithubAccessToken(userId);
@@ -26,21 +29,33 @@ public class GithubUserClientImpl implements GithubUserClient {
 	}
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "userFetchFallBack")
 	public GithubUserResponse fetchUser(String accessToken, Integer githubUserId) {
 
 		return githubUserFeignClient.fetchUser(accessToken, githubUserId);
 	}
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "userFetchFallBack")
 	public Response fetchUserRawResponse(String accessToken, Integer githubUserId) {
 		return githubUserFeignClient.fetchUserRawResponse(accessToken, githubUserId);
 	}
 
 	@Override
+	@CircuitBreaker(name = "githubApi", fallbackMethod = "userFetchFallBack")
 	public Response fetchUserRawResponse(Long userId, Integer githubUserId) {
 
 		String accessToken = githubOAuthTokenReader.getGithubAccessToken(userId);
 
 		return githubUserFeignClient.fetchUserRawResponse(accessToken, githubUserId);
 	}
+
+
+	private void userFetchFallBack(Long userId, Integer githubUserId, Throwable throwable) {
+		if(throwable instanceof CallNotPermittedException){
+
+		}
+		/// TODO : 에러코드 회의 후 처리
+	}
+
 }

--- a/Moyoy-Infra/src/main/resources/infra.yml
+++ b/Moyoy-Infra/src/main/resources/infra.yml
@@ -24,3 +24,17 @@ discord:
   webhook-uri:
     id: ${DISCORD_WEBHOOK_ID}
     token : ${DISCORD_WEBHOOK_TOKEN}
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      githubApi:
+        sliding-window-type: count_based
+        sliding-window-size: 100
+        minimum-number-of-calls: 10
+        wait-duration-in-open-state:
+          seconds: 20
+        failure-rate-threshold: 50
+        permitted-number-of-calls-in-half-open-state: 10
+        #record-exceptions: 기준이 될 에러 설정
+        #ignore-exceptions: 제외할 에러 설정


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #124  

## 🔎 PR 내용  

써킷 브레이커 도입을 위한 사전 작업을 진행했습니다.  

---

## 1️⃣ 써킷 브레이커의 필요성  

우리 프로젝트는 깃허브에서 제공하는 다양한 API를 활용해 사용자들에게 흥미로운 기능을 제공하는 서비스입니다.  
따라서 대부분의 기능이 깃허브 API 호출에 의존하고 있습니다.  

그렇기 때문에 만약 깃허브 서버에서 알 수 없는 **50X 에러**가 반복되거나, 서버 장애로 인해 지속적으로 네트워크 오류가 발생한다면 이는 곧 우리 서비스 장애로 이어질 수 있습니다.  

이러한 상황을 방지하기 위해 **써킷 브레이커(Circuit Breaker)** 를 도입했습니다.  

📚 참고자료  
- [우아한형제들: 써킷 브레이커 적용기](https://techblog.woowahan.com/15694/)  
- [올리브영: 써킷 브레이커 적용기](https://oliveyoung.tech/2023-08-31/circuitbreaker-inventory-squad/)  

---

## 2️⃣ 예외 상황 처리  

- **Resilience4j Circuit Breaker** 를 사용했습니다.  
- 세부 파라미터 값들은 추후 조정할 예정입니다.  
- 써킷 브레이커가 `OPEN` 상태일 경우 `CallNotPermittedException` 이 발생하며, 이에 대한 예외 처리가 필요합니다.  
  - 예: 비어있는 데이터를 클라이언트에 반환  
  - 예: “깃허브 서버가 혼잡합니다. 잠시 후 다시 시도해주세요.” 와 같은 사용자 친화적인 에러 메시지 제공  

현재는 프론트엔드 팀과 협의 후 결정할 수 있도록 **fallback 메서드만 정의**해두었으며, 구체적인 구현은 하지 않았습니다.  
