### PR TITLE
Setting: Setup API request limit

### DIFF
--- a/Moyoy-Api/build.gradle
+++ b/Moyoy-Api/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 
     // API 모듈에서 인증 관련 데이터를 RDB 에서 관리중이라 필요
     implementation "org.springframework.boot:spring-boot-starter-jdbc"
+
+    implementation'com.bucket4j:bucket4j-core:8.10.1'
 }
 
 

--- a/Moyoy-Api/src/main/java/com/moyoy/api/auth/security/config/SecurityConfig.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/auth/security/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import static org.springframework.security.access.hierarchicalroles.RoleHierarch
 
 import lombok.RequiredArgsConstructor;
 
+import org.apache.catalina.filters.RateLimitFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
@@ -27,6 +28,7 @@ import com.moyoy.api.auth.security.component.HttpCookieOAuth2AuthorizationReques
 import com.moyoy.api.auth.security.component.OAuth2AuthenticationFailureHandler;
 import com.moyoy.api.auth.security.component.OAuth2AuthenticationSuccessHandler;
 import com.moyoy.api.auth.security.component.RdbOAuth2AuthorizedClientService;
+import com.moyoy.api.common.filter.RateLimitingFilter;
 import com.moyoy.api.common.filter.RequestInfoMDCFilter;
 import com.moyoy.api.common.filter.UserContextMDCFilter;
 
@@ -46,6 +48,7 @@ public class SecurityConfig {
 	private final CustomAccessDeniedHandler accessDeniedHandler;
 	private final UserContextMDCFilter userContextMDCFilter;
 	private final RequestInfoMDCFilter requestInfoMDCFilter;
+	private final RateLimitingFilter rateLimitingFilter;
 
 	@Bean
 	public SecurityFilterChain moyoySecurityFilterChain(HttpSecurity http) throws Exception {
@@ -60,6 +63,7 @@ public class SecurityConfig {
 			.addFilterBefore(jwtAuthenticationFilter, OAuth2AuthorizationRequestRedirectFilter.class)
 			.addFilterBefore(jwtExceptionHandleFilter, JwtAuthenticationFilter.class)
 			.addFilterAfter(userContextMDCFilter, AnonymousAuthenticationFilter.class)
+			.addFilterAfter(rateLimitingFilter, JwtAuthenticationFilter.class)
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/health", "/").permitAll() // Health Check
 				.requestMatchers("/error/**", "/favicon.ico").permitAll() // Server Default

--- a/Moyoy-Api/src/main/java/com/moyoy/api/common/filter/RateLimitingFilter.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/common/filter/RateLimitingFilter.java
@@ -1,0 +1,69 @@
+package com.moyoy.api.common.filter;
+
+import static com.moyoy.common.constant.MoyoConstants.*;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.ConsumptionProbe;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import com.moyoy.api.common.util.ErrorResponseWriter;
+import com.moyoy.domain.support.error.CommonErrorCode;
+
+@Component
+public class RateLimitingFilter extends OncePerRequestFilter {
+
+	private final ProxyManager<String> proxyManager;
+	private final BucketConfiguration configuration;
+	private final ErrorResponseWriter errorResponseWriter;
+
+	public RateLimitingFilter(ProxyManager<String> proxyManager,
+		BucketConfiguration configuration, ErrorResponseWriter errorResponseWriter) {
+		this.proxyManager = proxyManager;
+		this.configuration = configuration;
+		this.errorResponseWriter = errorResponseWriter;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+		String key = resolveKey(request);
+		Bucket bucket = proxyManager.builder().build(key, () -> configuration);
+
+		ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+
+		if (probe.isConsumed()) {
+
+			response.setHeader("X-Rate-Limit-Remaining", String.valueOf(probe.getRemainingTokens()));
+			filterChain.doFilter(request, response);
+		}
+		else {
+
+			long waitNanos = probe.getNanosToWaitForRefill();
+			long retryAfterSeconds = TimeUnit.NANOSECONDS.toSeconds(waitNanos) + 1;
+			response.setHeader("Retry-After", String.valueOf(retryAfterSeconds));
+			errorResponseWriter.writeErrorResponse(response, TOO_MANY_REQUEST, CommonErrorCode.TOO_MANY_REQUEST);
+		}
+	}
+
+	private String resolveKey(HttpServletRequest request) {
+
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		if (auth != null && auth.isAuthenticated() && auth.getName() != null) {
+			return "token::user::" + auth.getName();
+		}
+
+		return "token::ip::" + request.getRemoteAddr();
+	}
+}

--- a/Moyoy-Common/src/main/java/com/moyoy/common/constant/MoyoConstants.java
+++ b/Moyoy-Common/src/main/java/com/moyoy/common/constant/MoyoConstants.java
@@ -23,6 +23,7 @@ public class MoyoConstants {
 	public static final int FORBIDDEN = 403;
 	public static final int NOT_FOUND = 404;
 	public static final int METHOD_NOT_ALLOWED = 405;
+	public static final int TOO_MANY_REQUEST = 429;
 	public static final int SERVER_ERROR = 500;
 
 	// JWT

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/support/error/CommonErrorCode.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/support/error/CommonErrorCode.java
@@ -2,6 +2,8 @@ package com.moyoy.domain.support.error;
 
 import static com.moyoy.common.constant.MoyoConstants.*;
 
+import com.moyoy.common.constant.MoyoConstants;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +16,7 @@ public enum CommonErrorCode implements BaseErrorCode {
 	INVALID_SORT_PARAM(BAD_REQUEST, "COMMON_400_3", "정렬 파라미터 형식을 다시 확인해 주세요."),
 	RESOURCE_NOT_FOUND(NOT_FOUND, "COMMON_404_1", "리소스를 찾을 수 없습니다."),
 	NOT_ALLOWED_METHOD(METHOD_NOT_ALLOWED, "COMMON_405_1", "허용되지 않은 메서드 입니다."),
+	TOO_MANY_REQUEST(MoyoConstants.TOO_MANY_REQUEST, "COMMON_429_1", "너무 많은 API를 호출했습니다. 나중에 재시도 해 주세요"),
 	UNKNOWN_INTERNAL_SERVER_ERROR(SERVER_ERROR, "COMMON_500_1", "서버 내부에서 알수 없는 에러가 발생 했습니다. 관리자에게 문의해 주세요."),
 	HTTP_CLIENT_ERROR(SERVER_ERROR, "COMMON_500_2", "API 서버와 깃허브 서버 통신중 에러가 발생했습니다.");
 

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/support/error/github_follow/FollowErrorCode.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/support/error/github_follow/FollowErrorCode.java
@@ -5,7 +5,6 @@ import static com.moyoy.common.constant.MoyoConstants.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import com.moyoy.common.constant.MoyoConstants;
 import com.moyoy.domain.support.error.BaseErrorCode;
 import com.moyoy.domain.support.error.ErrorReason;
 

--- a/Moyoy-Infra/build.gradle
+++ b/Moyoy-Infra/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 
     // resilience4j
     implementation "org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j"
+
+    // bucket4j
+    implementation'com.bucket4j:bucket4j-core:8.10.1'
+    implementation 'com.bucket4j:bucket4j-redis:8.10.1'
 }
 
 jar.enabled = true

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/redis/support/config/RateLimitConfig.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/redis/support/config/RateLimitConfig.java
@@ -1,0 +1,54 @@
+package com.moyoy.infra.database.redis.support.config;
+
+import static java.time.Duration.*;
+
+import java.time.Duration;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.command.CommandAsyncExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.distributed.proxy.ClientSideConfig;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.redis.redisson.cas.RedissonBasedProxyManager;
+
+@Configuration
+public class RateLimitConfig {
+
+	/** Redis에 저장될 버킷 상태의 만료 전략
+	 *  - 버킷이 다시 가득 찰 때까지의 시간 기준으로 TTL 설정 (안 쓰는 키 자동 정리)
+	 */
+	private static final ExpirationAfterWriteStrategy EXPIRATION =
+		ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(ofSeconds(10));
+
+	@Bean
+	public BucketConfiguration defaultBucketConfiguration() {
+		return BucketConfiguration.builder()
+			.addLimit(limit ->
+				limit.capacity(3)
+					.refillIntervally(3, Duration.ofMinutes(1))
+					.id("per-minute")
+			)
+			.build();
+	}
+
+
+	/** Redis 분산 버킷 매니저 (Redisson) */
+	@Bean
+	public ProxyManager<String> redissonProxyManager(RedissonClient redissonClient) {
+
+		// Bucket4j가 Redisson의 내부 CommandExecutor를 요구함
+		CommandAsyncExecutor commandExecutor = ((Redisson) redissonClient).getCommandExecutor();
+
+		ClientSideConfig config = ClientSideConfig.getDefault()
+			.withExpirationAfterWriteStrategy(EXPIRATION);
+
+		return RedissonBasedProxyManager.builderFor(commandExecutor)
+			.withClientSideConfig(config)
+			.build();
+	}
+}

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/redis/support/config/RateLimitConfig.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/redis/support/config/RateLimitConfig.java
@@ -29,8 +29,8 @@ public class RateLimitConfig {
 	public BucketConfiguration defaultBucketConfiguration() {
 		return BucketConfiguration.builder()
 			.addLimit(limit ->
-				limit.capacity(3)
-					.refillIntervally(3, Duration.ofMinutes(1))
+				limit.capacity(30)
+					.refillIntervally(30, Duration.ofMinutes(1))
 					.id("per-minute")
 			)
 			.build();

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/redis/support/config/RedisConfig.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/redis/support/config/RedisConfig.java
@@ -1,36 +1,31 @@
 package com.moyoy.infra.database.redis.support.config;
 
-import lombok.RequiredArgsConstructor;
-
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@RequiredArgsConstructor
 public class RedisConfig {
 
-	private final RedisProperties redisProperties;
+	private final String host;
+	private final int port;
+
+	public RedisConfig(
+		@Value("${spring.data.redis.host}") String host,
+		@Value("${spring.data.redis.port}") int port){
+
+		this.host = host;
+		this.port = port;
+	}
 
 	@Bean
 	public RedissonClient redissonClient() {
 		Config config = new Config();
 		config.useSingleServer()
-			.setAddress("redis://" + redisProperties.host + ":" + redisProperties.port);
+			.setAddress("redis://" + host + ":" + port);
 		return Redisson.create(config);
-	}
-
-	@RequiredArgsConstructor
-	@ConfigurationProperties("spring.data.redis")
-	static class RedisProperties {
-
-		private final String host;
-		private final int port;
 	}
 }

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/external/github/repo/GithubRepoFeignClient.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/external/github/repo/GithubRepoFeignClient.java
@@ -5,7 +5,6 @@ import static com.moyoy.common.constant.MoyoConstants.*;
 import java.util.List;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #126  

# API Rate Limit

API 보호를 위해 **API LIMIT**을 적용했습니다. 현재는 임시 설정이며 추후 보완할 예정입니다.  

---

## 1️⃣ 왜 API Limit이 필요한가

<img width="1632" height="483" alt="image" src="https://github.com/user-attachments/assets/1f4e565e-79f1-4bda-82cd-358911d879cd" />

우리 서비스에는 다양한 API가 존재합니다.  
- 단순 조회 API: DB에서 데이터를 가져와 가공 후 반환  
- 복잡 API: 서버 내부에서 통계·집계 데이터를 계산 후 응답  

만약 누군가 **악의적으로 무차별 호출**을 시도한다면,  
- 서버 과부하 발생  
- 분산락 같은 자원 획득에 지장 발생  

따라서 **API 호출 제한량**을 두고, 초과 시 비정상 사용자로 간주하여 **요청을 차단**하는 전략이 필요합니다.  

<br/>

<img width="962" height="76" alt="image" src="https://github.com/user-attachments/assets/e8cc1bf5-c862-4247-b6be-eebca6d260d4" />

> 위 스크린샷은 GitHub API의 Rate Limit 예시입니다.

---

## 2️⃣ 토큰 버킷 알고리즘

API Limit 구현을 위한 대표 알고리즘:  
- Fixed Window Counter  
- Sliding Window Log  
- Sliding Window Counter  
- **Token Bucket** ← 선택  
- Leaky Bucket  

우리 프로젝트에서는 **Token Bucket**으로 임시 구현을 진행했습니다.  

### 토큰 버킷 개념
- 사용자/IP 등 특정 Key별로 **토큰을 담아두는 버킷**을 둠.
- 요청 발생 시 **토큰을 1개씩 소비.
- 버킷에는 **최대 용량(capacity)** 이 정해져 있고, 토큰은 **일정 주기로 재충전(refill)** 됨.

---

## 3️⃣ 저장소 설계

서비스는 항상 **수평 확장**을 고려해야 합니다.
- 현재 서버는 1대지만, 추후 늘어날 수 있음 → **중앙 토큰 저장소 필요**  
- 선택: **Redis**  

### Redis 부담 문제
모든 API 서버에서 Redis 단일 노드로 요청 → 부하 위험성 존재.  
➡️ 해결책:  
- Redis도 단일 노드가 아니라 샤딩 필요  
- `UserId` 기준으로 토큰 저장소를 분할

### 통신 비용 최적화 아이디어
- `(Redis에 남은 토큰 수) ÷ (API 서버 노드 수)` 만큼 **각 API 서버로 토큰 분배**  
- 서버 로컬 버킷에서 사용 → 주기적으로 Redis와 동기화  
- **샤딩 + 로컬 캐싱 + 동기화** 조합 가능  

> 단, 이 부분은 현재 범위 밖이므로 나중에 고려해 보겠습니다.

---

## 4️⃣  Bucket4j를 이용한 구현

### 의존성 추가

```
    implementation'com.bucket4j:bucket4j-core:8.10.1'
    implementation 'com.bucket4j:bucket4j-redis:8.10.1'
```

bucket4j를 이용하면 토큰 버킷 알고리즘 + 레디스 저장소를 굉장히 간단하게 구현할 수 있습니다. 위의 의존성을 추가해 주고


```
@Configuration
public class RateLimitConfig {

	/** Redis에 저장될 버킷 상태의 만료 전략
	 *  - 버킷이 다시 가득 찰 때까지의 시간 기준으로 TTL 설정 (안 쓰는 키 자동 정리)
	 */
	private static final ExpirationAfterWriteStrategy EXPIRATION =
		ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(ofSeconds(10));

	@Bean
	public BucketConfiguration defaultBucketConfiguration() {
		return BucketConfiguration.builder()
			.addLimit(limit ->
				limit.capacity(30)
					.refillIntervally(30, Duration.ofMinutes(1))
					.id("per-minute")
			)
			.build();
	}


	/** Redis 분산 버킷 매니저 (Redisson) */
	@Bean
	public ProxyManager<String> redissonProxyManager(RedissonClient redissonClient) {

		// Bucket4j가 Redisson의 내부 CommandExecutor를 요구함
		CommandAsyncExecutor commandExecutor = ((Redisson) redissonClient).getCommandExecutor();

		ClientSideConfig config = ClientSideConfig.getDefault()
			.withExpirationAfterWriteStrategy(EXPIRATION);

		return RedissonBasedProxyManager.builderFor(commandExecutor)
			.withClientSideConfig(config)
			.build();
	}
}
```

위와 같은 Configuration을 작성했습니다.

<br/>

```
	@Bean
	public BucketConfiguration defaultBucketConfiguration() {
		return BucketConfiguration.builder()
			.addLimit(limit ->
				limit.capacity(30)
					.refillIntervally(30, Duration.ofMinutes(1))
					.id("per-minute")
			)
			.build();
	}
```

이 부분이 버킷을 설정하는 부분입니다. 버킷에 담을 최대 토큰 수는 30개로 설정했습니다.

```
.refillIntervally(30, Duration.ofMinutes(1))
.refillGreedy(30, Duration.ofMinutes(1))
```
토큰 리필 방법을 명시했습니다. intervally의 경우 1분에 30개를 충전, greedy의 경우 2초에 1개씩 1분에 30개를 충전하는 방식입니다.


<br/>

```
private static final ExpirationAfterWriteStrategy EXPIRATION =
		ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(ofSeconds(10));
```
만약 버킷에 토큰이 가득 차있다면 해당 버킷은 메모리 절약을 위해서 삭제합니다. 토큰이 가득 찼다는건 사용자가 API를 이용하지 않고 있다는 소리이고 사용자가 다시 토큰을 필요로 할 때, 새로운 버킷을 초기화 해주는 게 이득입니다.

물론 이 경우, 우연히 사용자의 토큰이 리필되자마자 사용자가 토큰을 사용하는 경우가 있을 겁니다. 이런 경우를 방지하기 위해서  
```
.basedOnTimeForRefillingBucketUpToMax(ofSeconds(10));
```
가득찬 토큰의 삭제시점을 유예할 수 있습니다.


<br/>

```
	/** Redis 분산 버킷 매니저 (Redisson) */
	@Bean
	public ProxyManager<String> redissonProxyManager(RedissonClient redissonClient) {

		// Bucket4j가 Redisson의 내부 CommandExecutor를 요구함
		CommandAsyncExecutor commandExecutor = ((Redisson) redissonClient).getCommandExecutor();

		ClientSideConfig config = ClientSideConfig.getDefault()
			.withExpirationAfterWriteStrategy(EXPIRATION);

		return RedissonBasedProxyManager.builderFor(commandExecutor)
			.withClientSideConfig(config)
			.build();
	}
``` 

bucket4j에게 우리가 사용하는 레디스 커넥터를 연결했습니다. 또한 위에서 본 가득찬 토큰 버킷 삭제 정책을 설정했습니다. 우리는 해당 매니저를 통해서 토큰을 꺼내오고 충전하는 등 API 레벨에서 관리가 가능합니다.





<br/>

```
@Component
public class RateLimitingFilter extends OncePerRequestFilter {

	private final ProxyManager<String> proxyManager;
	private final BucketConfiguration configuration;

```

API 호출량 제한은 횡단 관심사이고 AOP, 인터셉터, 필터중 원하는 선택지를 사용하면 될 거 같습니다.

저는 필터를 사용했습니다.


인증되지 않은 사용자는 ip + User Agent 기반으로, 인증된 사용자는 userId 기반으로 토큰을 제어할 생각입니다. 지금은 비인증 사용자는 ip만으로 제어중입니다. 이 부분은 좀 더 생각해보고 수정될 수 있을거 같습니다.

<br/>


### 응답 성공 예시

<img width="1250" height="381" alt="image" src="https://github.com/user-attachments/assets/03f68ffd-f5ef-4694-b2be-97d3ec675c4f" />


### 응답 실패 예시

<img width="1000" height="441" alt="image" src="https://github.com/user-attachments/assets/0add80c8-8105-42c9-b352-db4e20fafcab" />