### PR TITLE
fix: extract actual client IP instead of always using localhost

### DIFF
--- a/Moyoy-Api/src/main/java/com/moyoy/api/common/filter/RateLimitingFilter.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/common/filter/RateLimitingFilter.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import com.moyoy.api.common.util.ErrorResponseWriter;
@@ -64,6 +65,13 @@ public class RateLimitingFilter extends OncePerRequestFilter {
 			return "token::user::" + auth.getName();
 		}
 
-		return "token::ip::" + request.getRemoteAddr();
+		return "token::ip::" + extractClientIp(request);
+	}
+
+	private String extractClientIp(final HttpServletRequest request) {
+
+		return Optional.ofNullable(request.getHeader("X-Forwarded-For"))
+			.map(xff -> xff.split(",")[0].trim())
+			.orElse(request.getRemoteAddr());
 	}
 }


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #128  

<br/>

## 🔎 PR 내용

비인증 사용자에 대해 **IP 기반 API Limit**을 적용할 때, 모든 사용자의 IP가 동일하게 `127.0.0.1 (localhost)`로 인식되는 문제를 해결했습니다.

<br/>

### 📌 문제 상황
현재 테스트 서버 구조는 아래와 같이 **Nginx를 LB(로드밸런서) + 리버스 프록시 + HTTPS 처리** 용도로 사용하고 있습니다.  

<img width="1060" height="354" alt="image" src="https://github.com/user-attachments/assets/bc28b708-3b27-44e5-a078-53919d8e3c89" />

Nginx 설정에서는 실제 요청을 받아 **Spring App (localhost:8080)** 으로 프록시 전달하고 있습니다.  

<img width="439" height="112" alt="image" src="https://github.com/user-attachments/assets/b7a04cca-f76f-43bb-b6aa-4d3f7abba43f" />

이로 인해 Spring 애플리케이션에서  

```java
request.getRemoteAddr()
```

를 사용하면 항상 127.0.0.1로만 인식되는 문제가 발생했습니다.
<br/>

이를 해결하기위해 Nginx에서 실제 클라이언트 IP를 X-Forwarded-For 헤더로 넘기고 이를 Spring App 쪽에서 파싱해서 사용했습니다.



---

### AS-IS

<img width="233" height="26" alt="image" src="https://github.com/user-attachments/assets/4dbd86ff-5e18-4b0d-870b-0706fe0aff78" />


### TO-BE

<img width="233" height="50" alt="image" src="https://github.com/user-attachments/assets/f4c8c3b8-dd7b-404a-92dc-c32feed4a472" />





