### PR TITLE
setting: Add actuator

### DIFF
--- a/Moyoy-Api/build.gradle
+++ b/Moyoy-Api/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-jdbc"
 
     implementation'com.bucket4j:bucket4j-core:8.10.1'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 

--- a/Moyoy-Api/build.gradle
+++ b/Moyoy-Api/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation'com.bucket4j:bucket4j-core:8.10.1'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 

--- a/Moyoy-Api/src/main/java/com/moyoy/api/auth/security/config/ActuatorSecurityConfig.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/auth/security/config/ActuatorSecurityConfig.java
@@ -1,0 +1,48 @@
+package com.moyoy.api.auth.security.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class ActuatorSecurityConfig {
+
+	@Value("${actuator.monitoring.password}")
+	private String monitoringPassword;
+
+	@Bean
+	@Order(1)
+	public SecurityFilterChain actuatorFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.securityMatcher("/actuator/**")
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/actuator/prometheus")
+				.hasRole("MONITORING"))
+			.httpBasic(Customizer.withDefaults())
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.build();
+	}
+
+	@Bean
+	public InMemoryUserDetailsManager userDetailsService() {
+
+		UserDetails monitoring = User.builder()
+			.username("prometheus")
+			.password("{noop}" + monitoringPassword)
+			.roles("MONITORING")
+			.build();
+
+		return new InMemoryUserDetailsManager(monitoring);
+	}
+
+}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/auth/security/config/SecurityConfig.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/auth/security/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -50,6 +51,7 @@ public class SecurityConfig {
 	private final RateLimitingFilter rateLimitingFilter;
 
 	@Bean
+	@Order(2)
 	public SecurityFilterChain moyoySecurityFilterChain(HttpSecurity http) throws Exception {
 
 		http
@@ -71,6 +73,7 @@ public class SecurityConfig {
 				.requestMatchers("/api/v1/rankings").permitAll() // [Domain] Ranking
 				.requestMatchers(GET, "/api/v1/pr-review").permitAll()
 				.requestMatchers("/api/v1/pr-review/{pr-reviewId}").permitAll()
+				.requestMatchers("/actuator/**").permitAll()
 				.anyRequest().authenticated())
 			.oauth2Login(oauth2 -> oauth2
 				.authorizationEndpoint(authorization -> authorization

--- a/Moyoy-Api/src/main/resources/application.yml
+++ b/Moyoy-Api/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
     secret: ${JWT_SECRET_KEY}
 
   cors:
-    allow-origin: ${ALLOW_ORIGIN:http://localhost:5173}
+    allow-origin: ${ALLOW_ORIGIN:http://localhost:5173}4
 
   cookie:
     samesite: ${COOKIE_SAME_SITE:Strict}
@@ -29,3 +29,15 @@ spring:
 
 logging:
   config: classpath:logback/logback-${spring.profiles.active:local}.xml
+
+management:
+  server:
+    port: 9090
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+
+actuator:
+  monitoring:
+    password: ${PROMETHEUS_PASSWORD:prometheus}


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #141 

<br />

## 🔎 PR 내용

API 서버 모니터링을 진행했습니다.

<img width="1112" height="725" alt="image" src="https://github.com/user-attachments/assets/b11f76be-9679-47e4-a3da-d0a642f81212" />

처음 간단히 생각해본 모니터링 관련 인프라는 위와 같습니다. 

<br/><br/>

<img width="1150" height="608" alt="image" src="https://github.com/user-attachments/assets/d80d38ec-17fe-4d4c-9c16-670dd052b78d" />

일단은 테스트 서버에 실험해 보기위해서 API 서버 모니터링을 위와 같이 진행해 봤습니다.

<br/><br/>

## 1️⃣ API Server 측 설정

```
implementation 'org.springframework.boot:spring-boot-starter-actuator'
implementation 'io.micrometer:micrometer-registry-prometheus'
```

모니터링 서버의 prometheus에서 필요한 메트릭을 가져갈 수 있게 위와 같은 의존성을 추가합니다.

<br/>

```
management:
  server:
    port: 9090
  endpoints:
    web:
      exposure:
        include: prometheus
```
그 후, 위와 같이 액츄에이터 전용 포트와 Prometheus 노출을 허용했습니다.



<br/><br/>

<img width="551" height="240" alt="image" src="https://github.com/user-attachments/assets/da6408d8-89d7-4272-8fc4-5ac071cc7c50" />

위와 같이 확인이 가능합니다.


프로메테우스에서 추후 API 서버://9090/actuator/prometheus로 프로메테우스 전용 메트릭 수집 요청을 보낼것 이기 때문에 위와 같이 설정했습니다.

또한, 기존의 HTTP 요청을 받는 8080 포트와 모니터링을 위한 9090 포트를 분리하면 9090로 들어오는 트래픽은 특정 IP가 아니면 차단 같은 효과를 쓸 수 있습니다.

<br/><br/>

물론 이렇게만 설정하면 어떻게든 뚫고 들어올 위험이 있기 때문에 Spring Security를 이용해서 추가적인 인증을 거치게 했습니다.

[Actuator 보안 가이드 블로그](https://notavoid.tistory.com/70)를 보고 진행했습니다.



<br/><br/>

<img width="620" height="402" alt="image" src="https://github.com/user-attachments/assets/153f17f3-3e96-4606-b3aa-17391e5b0ca8" />

현재 문제가 되는 부분은 위와같이 어떻게든 IP 주소를 조작해서 API 서버의 9090 포트로 접속에 성공하면 /actuator/prometheus 경로로 API 서버에 요청을 날렸을 때 위와 같이 프로메테우스를 위한 메트릭이 노출된다는 문제가 생깁니다.



<br/><br/>

```
@Configuration
@EnableWebSecurity
public class ActuatorSecurityConfig {

	@Value("${actuator.monitoring.password}")
	private String monitoringPassword;

	@Bean
	@Order(1)
	public SecurityFilterChain actuatorFilterChain(HttpSecurity http) throws Exception {
		return http
			.securityMatcher("/actuator/**")
			.authorizeHttpRequests(auth -> auth
				.requestMatchers("/actuator/prometheus")
				.hasRole("MONITORING"))
			.httpBasic(Customizer.withDefaults())
			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
			.build();
	}

	@Bean
	public InMemoryUserDetailsManager userDetailsService() {

		UserDetails monitoring = User.builder()
			.username("prometheus")
			.password("{noop}" + monitoringPassword)
			.roles("MONITORING")
			.build();

		return new InMemoryUserDetailsManager(monitoring);
	}

}
```

이를 위해 위와 같이 Actuator 전용 SecurityFilterChain을 구성했습니다. 시큐리티 필터체인은 여러가지를 등록할 수 있는데 Order(1)를 통해서 일단 해당 필터에서 처리되어야 할 요청인지 구분하고 그게 아니면 기존의 우리의 시큐리티 필터체인으로 가도록 했습니다.


<br/><br/>

<img width="544" height="391" alt="image" src="https://github.com/user-attachments/assets/d8183ce9-2d68-46bc-a577-853030df11f9" />

이제 API 서버의 9090 포트의 허용된 IP를 어떻게든 뚫고 들어와도 위와 같이 추가적인 인증을 거치게 됩니다.




## 2️⃣ Prometheus 설정


```
scrape_configs:
  - job_name: 'spring-actuator'
    metrics_path: '/actuator/prometheus'
    static_configs:
      - targets: ['localhost:9090']
    scrape_interval: 5s
    basic_auth:
      username: 'prometheus'
      password: 'prometheus'
```

Prometheus.yml을 위와같이 수정했습니다. 로컬 환경에서 한 개의 노트북에서 API 서버와 프로메테우스를 함께 돌려보고 싶다면 API 쪽 Management Port를 9091로 수정하면 됩니다.

프로메테우스의 기본 포트는 9090입니다.


<br/><br/>


<img width="1867" height="193" alt="image" src="https://github.com/user-attachments/assets/689bbf27-6565-4ae5-85d2-e246db75e1f4" />

이제 프로메테우스를 로컬에서 실행해 보면 위와 같이 정상적으로 Spring Actuator가 만들어둔 프로메테우스 전용 메트릭을 프로메테우스에서 Pull 하고 있음을 확인 가능합니다.

<br/>

<img width="358" height="223" alt="image" src="https://github.com/user-attachments/assets/7c74a9aa-aafe-4c66-a3df-c3773d64b847" />

만일 의도적으로 비밀번호를 잘못 입력하게 되면

<img width="793" height="265" alt="image" src="https://github.com/user-attachments/assets/8366e602-0d8e-42c1-b919-110bee05b3c5" />

이렇게 인증실패 오류가 발생합니다.


<br/><br/>

 

## 3️⃣ Grafana 설정

<img width="1029" height="606" alt="image" src="https://github.com/user-attachments/assets/8a5cac5a-d0a7-409c-a9e3-f84cabd38684" />

그라라파나 대시보드에서 spring을 검색해보면 Spring Boot 2.1 과 Spring Boot Obsibility를 확인할 수 있습니다.

우리는 Prometheus, Loki를 함께 사용할 것이기 때문에 Spring Boot Obsibility가 필요합니다. 다만, 로깅 작업을 지금 처리할 것은 아니기 때문에 Spring Boot 2.1을 임시로 사용할 생각입니다.


<br/>

<img width="274" height="403" alt="image" src="https://github.com/user-attachments/assets/1cc2dfe4-2f53-4fb4-b730-328a39c91612" />

해당 ID를 복사하고 로컬에서 그라파나를 실행후 대시보드 생성에서 Import 해줍니다.


<br/>

<img width="1906" height="691" alt="image" src="https://github.com/user-attachments/assets/c1548986-c6e0-4b8b-b2f9-3e12f27417ad" />

위와 같이 정상 동작하는 것까지 확인할 수 있습니다.


<br/><br/>

## 4️⃣ 테스트 서버 AWS 환경에 구축해보기

<img width="1165" height="598" alt="image" src="https://github.com/user-attachments/assets/9a38e0a2-7f35-47de-9d10-6b6132b83b0d" />

현재 Test API 서버는 위와 같이 구성되어 있습니다. 모니터링 서버는 별도의 EC2에 구성할 생각입니다. 또한, 추후 운영서버가 배포되면 테스트 서버의 모니터링은 제거할 예정입니다.






