### PR TITLE
Setting: Add TraceId to Log

### DIFF
--- a/.github/workflows/api-dev-deploy.yml
+++ b/.github/workflows/api-dev-deploy.yml
@@ -62,5 +62,5 @@ jobs:
             mv /home/ubuntu/moyoy-dev/api/tobe/moyoy-api.jar /home/ubuntu/moyoy-dev/api/current/moyoy-api.jar
             cd /home/ubuntu/moyoy-dev/api/current
             sudo fuser -k -n tcp 8080 || true    
-            nohup java -jar moyoy-api.jar --spring.profiles.active=dev > ./output.log 2>&1 &
+            nohup java -Duser.timezone=Asia/Seoul -jar moyoy-api.jar --spring.profiles.active=dev > ./output.log 2>&1 &
             rm -rf /home/ubuntu/moyoy-dev/api/tobe

--- a/.github/workflows/batch-dev-deploy.yml
+++ b/.github/workflows/batch-dev-deploy.yml
@@ -62,5 +62,5 @@ jobs:
             mv /home/ubuntu/moyoy-dev/batch/tobe/moyoy-batch.jar /home/ubuntu/moyoy-dev/batch/current/moyoy-batch.jar
             cd /home/ubuntu/moyoy-dev/batch/current
             sudo fuser -k -n tcp 9000 || true    
-            nohup java -jar moyoy-batch.jar --spring.profiles.active=dev > ./output.log 2>&1 &
+            nohup java -Duser.timezone=Asia/Seoul -jar moyoy-batch.jar --spring.profiles.active=dev > ./output.log 2>&1 &
             rm -rf /home/ubuntu/moyoy-dev/batch/tobe

--- a/Moyoy-Api/src/main/java/com/moyoy/api/common/filter/RequestInfoMDCFilter.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/common/filter/RequestInfoMDCFilter.java
@@ -1,6 +1,7 @@
 package com.moyoy.api.common.filter;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
@@ -19,12 +20,14 @@ public class RequestInfoMDCFilter extends OncePerRequestFilter {
 	private static final String QUERY_STRING = "queryString";
 	private static final String REFERER = "Referer";
 	private static final String HOST = "Host";
+	private static final String TRACE_ID = "traceId";
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-		throws ServletException,
-			IOException {
+		throws ServletException, IOException {
+
 		try {
+			MDC.put(TRACE_ID, UUID.randomUUID().toString());
 			MDC.put(REQUEST_URI, request.getRequestURI());
 			MDC.put(HTTP_METHOD, request.getMethod());
 			MDC.put(QUERY_STRING, getHeaderOrDefault(request.getQueryString(), ""));

--- a/Moyoy-Api/src/main/resources/logback/logback-dev.xml
+++ b/Moyoy-Api/src/main/resources/logback/logback-dev.xml
@@ -40,6 +40,7 @@
                 <fieldName>threadName</fieldName>
             </threadName>
             <mdc>
+                <includeMdcKeyName>traceId</includeMdcKeyName>
                 <includeMdcKeyName>userId</includeMdcKeyName>
                 <includeMdcKeyName>ip</includeMdcKeyName>
                 <includeMdcKeyName>userAgent</includeMdcKeyName>


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #143 

<br />

## 🔎 PR 내용

현재 우리 서버의 로그에는 TraceId가 존재하지 않습니다.

여러 사용자가 같은 시간대에 서비스를 이용하게 되면 해당 사용자들의 로그가 섞이게 될텐데 이 때 HTTP Request 단위로 UUID인 TraceId가 있다면 편리하게 각각의 HTTP Reqeust를 추적할 수 있게 됩니다. 

<img width="669" height="342" alt="image" src="https://github.com/user-attachments/assets/56dbf6ec-30ac-4f6f-a1ae-077d78ba0391" />

예를 들어 어떤 사용자가 하나의 API를 요청했을 때 해당 요청에 대해 여러가지 로그가 찍혔다면 위와 같이 해당 Reqeust 의 Trace Id를 통해서 해당 요청에 대한 로그만 모아 볼 수 있습니다.

