### PR TITLE
Fix: Correct deployment file path typo

### DIFF
--- a/.github/workflows/api-prod-deploy.yml
+++ b/.github/workflows/api-prod-deploy.yml
@@ -46,7 +46,7 @@ jobs:
           username: ${{ secrets.PROD_SERVER_EC2_USERNAME }}
           key: ${{ secrets.PROD_SERVER_EC2_PRIVATE_KEY }}
           source: moyoy-api.jar
-          target: /home/ubuntu/moyoy-dev/api/tobe
+          target: /home/ubuntu/moyoy-prod/api/tobe
 
       - name: SSH로 EC2에 접속 후 애플리케이션 실행
         uses: appleboy/ssh-action@v1.0.3
@@ -56,10 +56,10 @@ jobs:
           key: ${{ secrets.PROD_SERVER_EC2_PRIVATE_KEY }}
           script_stop: true
           script: |
-            rm -rf /home/ubuntu/moyoy-dev/api/current
-            mkdir /home/ubuntu/moyoy-dev/api/current
-            mv /home/ubuntu/moyoy-dev/api/tobe/moyoy-api.jar /home/ubuntu/moyoy-dev/api/current/moyoy-api.jar
-            cd /home/ubuntu/moyoy-dev/api/current
+            rm -rf /home/ubuntu/moyoy-prod/api/current
+            mkdir /home/ubuntu/moyoy-prod/api/current
+            mv /home/ubuntu/moyoy-prod/api/tobe/moyoy-api.jar /home/ubuntu/moyoy-prod/api/current/moyoy-api.jar
+            cd /home/ubuntu/moyoy-prod/api/current
             sudo fuser -k -n tcp 8080 || true    
-            nohup java -Duser.timezone=Asia/Seoul -jar moyoy-api.jar --spring.profiles.active=dev > ./output.log 2>&1 &
-            rm -rf /home/ubuntu/moyoy-dev/api/tobe
+            nohup java -Duser.timezone=Asia/Seoul -jar moyoy-api.jar --spring.profiles.active=prod > ./output.log 2>&1 &
+            rm -rf /home/ubuntu/moyoy-prod/api/tobe

--- a/.github/workflows/batch-prod-deploy.yml
+++ b/.github/workflows/batch-prod-deploy.yml
@@ -46,7 +46,7 @@ jobs:
           username: ${{ secrets.BATCH_SERVER_EC2_USERNAME }}
           key: ${{ secrets.BATCH_SERVER_EC2_PRIVATE_KEY }}
           source: moyoy-batch.jar
-          target: /home/ubuntu/moyoy-dev/batch/tobe
+          target: /home/ubuntu/moyoy-prod/batch/tobe
 
       - name: SSH로 EC2에 접속 후 애플리케이션 실행
         uses: appleboy/ssh-action@v1.0.3
@@ -56,10 +56,10 @@ jobs:
           key: ${{ secrets.BATCH_SERVER_EC2_PRIVATE_KEY }}
           script_stop: true
           script: |
-            rm -rf /home/ubuntu/moyoy-dev/batch/current
-            mkdir /home/ubuntu/moyoy-dev/batch/current
-            mv /home/ubuntu/moyoy-dev/batch/tobe/moyoy-batch.jar /home/ubuntu/moyoy-dev/batch/current/moyoy-batch.jar
-            cd /home/ubuntu/moyoy-dev/batch/current
+            rm -rf /home/ubuntu/moyoy-prod/batch/current
+            mkdir /home/ubuntu/moyoy-prod/batch/current
+            mv /home/ubuntu/moyoy-prod/batch/tobe/moyoy-batch.jar /home/ubuntu/moyoy-prod/batch/current/moyoy-batch.jar
+            cd /home/ubuntu/moyoy-prod/batch/current
             sudo fuser -k -n tcp 9000 || true    
-            nohup java -Duser.timezone=Asia/Seoul -jar moyoy-batch.jar --spring.profiles.active=dev > ./output.log 2>&1 &
-            rm -rf /home/ubuntu/moyoy-dev/batch/tobe
+            nohup java -Duser.timezone=Asia/Seoul -jar moyoy-batch.jar --spring.profiles.active=prod > ./output.log 2>&1 &
+            rm -rf /home/ubuntu/moyoy-prod/batch/tobe


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #155 

## 🔎 PR 내용

- 배포 워크플로우 파일에서 **`prod` 환경을 `dev`로 잘못 기재한 부분**을 수정했습니다.  


### 📌 변경 사항
- GitHub Actions 배포 파일 내 환경명 수정 (`dev` → `prod`)
