### PR TITLE
refactor: update RankingCalculator scoring logic

### DIFF
--- a/Moyoy-Batch/src/main/java/com/moyoy/batch/job/processor/CalculateRankingResultProcessor.java
+++ b/Moyoy-Batch/src/main/java/com/moyoy/batch/job/processor/CalculateRankingResultProcessor.java
@@ -25,6 +25,7 @@ public class CalculateRankingResultProcessor implements ItemProcessor<UserSummar
 
 	@Override
 	public UserRankResult process(UserSummaryContext userSummaryContext) {
+
 		List<GithubRepoDetails> candidateRepos = userSummaryContext.repoCandidatesContext().candidateRepos();
 		UserProfileContext userProfileContext = userSummaryContext.repoCandidatesContext().userProfileContext();
 		Long userId = userProfileContext.auth().userId();

--- a/Moyoy-Batch/src/main/java/com/moyoy/batch/scheduler/DailyRankingJobScheduler.java
+++ b/Moyoy-Batch/src/main/java/com/moyoy/batch/scheduler/DailyRankingJobScheduler.java
@@ -18,7 +18,7 @@ public class DailyRankingJobScheduler {
 	private final JobLauncher jobLauncher;
 	private final Job rankCalculationJob;
 
-	@Scheduled(cron = "50 14 16 * * *")
+	@Scheduled(cron = "00 00 00 * * *")
 	public void runRankingJob() throws Exception {
 
 		JobParameters params = new JobParametersBuilder()

--- a/Moyoy-Batch/src/main/java/com/moyoy/batch/scheduler/DailyRankingJobScheduler.java
+++ b/Moyoy-Batch/src/main/java/com/moyoy/batch/scheduler/DailyRankingJobScheduler.java
@@ -18,7 +18,7 @@ public class DailyRankingJobScheduler {
 	private final JobLauncher jobLauncher;
 	private final Job rankCalculationJob;
 
-	@Scheduled(cron = "00 00 00 * * *")
+	@Scheduled(cron = "50 14 16 * * *")
 	public void runRankingJob() throws Exception {
 
 		JobParameters params = new JobParametersBuilder()

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/ranking/RankingCalculator.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/ranking/RankingCalculator.java
@@ -5,112 +5,166 @@ import org.springframework.stereotype.Component;
 import com.moyoy.domain.ranking.dto.RankingCalculatorParameters;
 import com.moyoy.domain.ranking.dto.RankingCalculatorResult;
 
-/**
- * TODO: 기간(주/월/년)별 랭킹 산정 로직 분기 필요
- *
- * <p><b>AS-IS</b>:
- * <ul>
- *   <li>모든 기간(WEEK, MONTH, YEAR)에 대해 동일한 지표와 산식 사용</li>
- *   <li>Grade(등급) 또한 기간 구분 없이 동일한 기준으로 산출</li>
- * </ul>
- *
- * <p><b>TO-BE</b>:
- * <ul>
- *   <li>기간별로 다른 지표 또는 가중치 적용 (예: 주간은 단기 성과, 연간은 누적 성과 반영)</li>
- *   <li>Grade(등급)는 <b>연간(YEAR)</b> 기준으로만 산출</li>
- *   <li>주간/월간은 점수(포인트)만 산출하고, 등급은 부여하지 않음</li>
- * </ul>
- *
- * <p><b>비고</b>:
- * - 현재는 모든 기간의 랭킹이 동일하게 계산되므로,
- *   단기 성과(주간)와 장기 성과(연간)의 차이를 반영하지 못함.
- * - 분기 처리가 완료되면 등급은 "연간 성과"만 대표하도록 변경 예정.
- * </p>
- */
-
 @Component
 public class RankingCalculator {
 
 	/**
-	 * <H1>랭킹 산정 기준 상수</H1>
+	 * <h1>랭킹 산정 기준 상수</h1>
 	 *
-	 * <p>GitHub 활동 지표(커밋, 커밋 라인 수, 스타, 팔로워)를 기반으로
-	 * 백분위와 등급을 계산하기 위한 기준값들입니다.</p>
-	 * 각 평가 항목의 중앙값(Median)과 가중치(Weight).
+	 * <p>GitHub 활동 데이터를 점수화하고 등급을 매기기 위해 사용되는 기준값 모음.</p>
 	 *
+	 * <h2>Median (중앙값)</h2>
 	 * <ul>
-	 *   <li><b>Median</b>: 분포의 중심값 (50% 사용자가 이 값보다 낮고, 50%는 높음)</li>
-	 *   <li><b>Weight</b>: 전체 점수 산정 시 해당 항목의 비중</li>
+	 *   <li>연간(YEAR) 기준값을 정의하고, 월간(MONTH)·주간(WEEK)은 연간 값을 12, 52로 나눈 근사치</li>
+	 *   <li>스타/팔로워는 누적 데이터이므로 기간 구분 없이 단일 Median 사용</li>
 	 * </ul>
 	 *
-	 * <p>현행</p>
+	 * <h2>Weight (가중치)</h2>
 	 * <ul>
+	 *   <li>각 지표가 랭킹 점수에 기여하는 비중</li>
 	 *   <li>커밋 수와 커밋 라인 수는 기여도의 핵심 지표이므로 높은 가중치 부여</li>
-	 *   <li>스타 수와 팔로워 수는 활동의 "외부 인지도"를 반영하되 영향력은 낮음</li>
+	 *   <li>스타/팔로워는 외부 인지도를 반영하지만 상대적으로 낮은 가중치</li>
+	 * </ul>
+	 *
+	 * <h2>Thresholds & Levels</h2>
+	 * <ul>
+	 *   <li>퍼센타일(0~100) 값에 따라 등급(Level)을 매핑하는 기준</li>
+	 *   <li>{@code THRESHOLDS} : 누적 백분위 경계값 배열</li>
+	 *   <li>{@code LEVELS} : 각 구간에 대응하는 등급 ("S" ~ "C")</li>
+	 *   <li>예: 퍼센타일이 20 → THRESHOLDS[2]=25 이하 → LEVELS[2]="A"</li>
 	 * </ul>
 	 */
-	private static final double COMMITS_MEDIAN = 100.0, COMMITS_WEIGHT = 3.0;
-	private static final double COMMITS_LINES_MEDIAN = 5000.0, COMMITS_LINES_WEIGHT = 5.0;
-	private static final double STARS_MEDIAN = 10.0, STARS_WEIGHT = 1.0;
-	private static final double FOLLOWERS_MEDIAN = 30.0, FOLLOWERS_WEIGHT = 1.0;
 
-	/// 전체 가중치 총합 (10.0)
+	private static final double YEARLY_COMMITS_MEDIAN = 100.0;
+	private static final double MONTHLY_COMMITS_MEDIAN = YEARLY_COMMITS_MEDIAN / 12;
+	private static final double WEEKLY_COMMITS_MEDIAN = YEARLY_COMMITS_MEDIAN / 52;
+
+	private static final double YEARLY_COMMITS_LINES_MEDIAN = 5000.0;
+	private static final double MONTHLY_COMMITS_LINES_MEDIAN = YEARLY_COMMITS_LINES_MEDIAN / 12;
+	private static final double WEEKLY_COMMITS_LINES_MEDIAN = YEARLY_COMMITS_LINES_MEDIAN / 52;
+
+	private static final double STARS_MEDIAN = 10.0;
+	private static final double FOLLOWERS_MEDIAN = 30.0;
+
+	private static final double COMMITS_WEIGHT = 3.0;
+	private static final double COMMITS_LINES_WEIGHT = 5.0;
+	private static final double STARS_WEIGHT = 1.0;
+	private static final double FOLLOWERS_WEIGHT = 1.0;
 	private static final double TOTAL_WEIGHT = COMMITS_WEIGHT + COMMITS_LINES_WEIGHT + STARS_WEIGHT + FOLLOWERS_WEIGHT;
 
-	/**
-	 * 누적 백분위(Percentile) 기준값 배열.
-	 *
-	 * <p>계산된 퍼센타일 값이 이 배열의 값 이하일 경우,
-	 * 동일 인덱스의 {@link #LEVELS} 등급을 부여합니다.</p>
-	 *
-	 * <p>예시: 퍼센타일이 20이라면 {@code THRESHOLDS[2] = 25} 이하이므로
-	 * {@code LEVELS[2] = "A"} 등급을 부여.</p>
-	 *
-	 * <p>퍼센타일이 낮을수록 더 높은 성과를 의미합니다.</p>
-	 */
 	private static final double[] THRESHOLDS = {1, 12.5, 25, 37.5, 50, 62.5, 75, 87.5, 100};
 	private static final String[] LEVELS = {"S", "A+", "A", "A-", "B+", "B", "B-", "C+", "C"};
 
+	/**
+	 * 주간/월간/연간 점수와 연간 등급을 계산한다.
+	 *
+	 * <p>계산 절차:</p>
+	 * <ol>
+	 *   <li>{@link #calculateRankingPoint} 를 호출하여
+	 *       주간(WEEK), 월간(MONTH), 연간(YEAR) 각각의 점수를 산출</li>
+	 *   <li>{@link #calculateRankingGrade} 를 호출하여
+	 *       연간(YEAR) 기준으로만 최종 등급을 산출</li>
+	 *   <li>세 개의 점수와 하나의 등급을 {@link RankingCalculatorResult} 에 담아 반환</li>
+	 * </ol>
+	 *
+	 * <p><b>특징</b>:</p>
+	 * <ul>
+	 *   <li>점수는 모든 기간(주/월/년)에 대해 제공</li>
+	 *   <li>등급은 연간 기준으로만 제공 (주/월은 점수만 산출)</li>
+	 * </ul>
+	 *
+	 * @param rankingParameters GitHub 활동 지표 (주/월/년 단위 통계 포함)
+	 * @return 주간/월간/연간 점수와 연간 등급을 담은 {@link RankingCalculatorResult}
+	 */
+
 	public RankingCalculatorResult calculate(RankingCalculatorParameters rankingParameters) {
 
-		int starCount = rankingParameters.stars();
-		int followerCount = rankingParameters.followers();
+		long weekPoint = calculateRankingPoint(rankingParameters, RankingPeriod.WEEK);
+		long monthPoint = calculateRankingPoint(rankingParameters, RankingPeriod.MONTH);
+		long yearPoint = calculateRankingPoint(rankingParameters, RankingPeriod.YEAR);
 
-		long weekPoint = calculateRankingPoint(rankingParameters.weekStats().commits(), rankingParameters.weekStats().commitLines(), starCount, followerCount, RankingPeriod.WEEK);
-		long monthPoint = calculateRankingPoint(rankingParameters.monthStats().commits(), rankingParameters.monthStats().commitLines(), starCount, followerCount, RankingPeriod.MONTH);
-		long yearPoint = calculateRankingPoint(rankingParameters.yearStats().commits(), rankingParameters.yearStats().commitLines(), starCount, followerCount, RankingPeriod.YEAR);
-		String grade = calculateRankingGrade(rankingParameters.yearStats().commits(), rankingParameters.yearStats().commitLines(), starCount, followerCount);
+		String grade = calculateRankingGrade(rankingParameters);
 
 		return new RankingCalculatorResult(weekPoint, monthPoint, yearPoint, grade);
 	}
 
 	/**
-	 * 특정 사용자의 GitHub 활동 지표를 기반으로 최종 랭킹 등급을 산출합니다.
+	 * 특정 기간(주간/월간/연간)의 GitHub 활동 지표를 기반으로 점수를 계산한다.
 	 *
 	 * <p>계산 절차:</p>
 	 * <ol>
-	 *   <li>{@link #calculatePercentile(int, int, int, int)} 로 백분위(0~100)를 계산</li>
-	 *   <li>백분위 값이 {@link #THRESHOLDS} 배열의 어느 구간에 속하는지 판별</li>
-	 *   <li>해당 구간의 {@link #LEVELS} 값을 반환</li>
+	 *   <li>기간(duration)에 맞는 커밋 수와 커밋 라인 수를 {@link RankingCalculatorParameters} 에서 추출</li>
+	 *   <li>스타 수와 팔로워 수는 기간 구분 없이 누적 값을 사용</li>
+	 *   <li>{@link #calculatePercentile} 메서드로 활동 지표 기반 백분위(0~100)를 계산</li>
+	 *   <li>(100 - 백분위) * 10,000 * 기간 비율(duration.getWeight())로 점수를 산출</li>
+	 *   <li>long으로 캐스팅하여 정수 점수를 반환</li>
 	 * </ol>
 	 *
-	 * <p>랭킹 산정 기준:</p>
+	 * <p><b>특징</b>:</p>
 	 * <ul>
-	 *   <li>커밋 개수 (사용자/조직의 실제 기여 커밋)</li>
-	 *   <li>커밋 라인 수 (커밋 개수보다 더 중요한 요소)</li>
-	 *   <li>스타 수 (상대적으로 낮은 가중치)</li>
-	 *   <li>팔로워 수 (상대적으로 낮은 가중치)</li>
+	 *   <li>백분위가 낮을수록 (활동량 ↑) 점수가 높게 산출됨</li>
+	 *   <li>기간별 비율(duration.getWeight())을 곱해 주간/월간/연간 점수를 상대적으로 보정</li>
+	 *   <li>출력되는 점수는 정수(long) 단위로 관리됨</li>
 	 * </ul>
 	 *
-	 * @param commits    총 커밋 수
-	 * @param commitLines 총 커밋 코드 라인 수
-	 * @param stars      총 star 개수
-	 * @param followers  사용자의 팔로워 수
-	 * @return           등급 문자열 ("S" ~ "C")
+	 * @param rankingParameters GitHub 활동 지표 (기간별/누적 데이터 포함)
+	 * @param duration 계산 대상 기간 ({@link RankingPeriod})
+	 * @return 산출된 점수(long)
 	 */
-	private String calculateRankingGrade(int commits, int commitLines, int stars, int followers) {
 
-		double percentile = calculatePercentile(commits, commitLines, stars, followers);
+	private long calculateRankingPoint(RankingCalculatorParameters rankingParameters, RankingPeriod duration) {
+
+		int commits = switch (duration) {
+			case WEEK -> rankingParameters.weekStats().commits();
+			case MONTH -> rankingParameters.monthStats().commits();
+			case YEAR -> rankingParameters.yearStats().commits();
+		};
+
+		int commitLines = switch (duration) {
+			case WEEK -> rankingParameters.weekStats().commitLines();
+			case MONTH -> rankingParameters.monthStats().commitLines();
+			case YEAR -> rankingParameters.yearStats().commitLines();
+		};
+
+		int stars = rankingParameters.stars();
+		int followers = rankingParameters.followers();
+
+		double percentile = calculatePercentile(commits, commitLines, stars, followers, duration);
+
+		return (long)((100 - percentile) * 100_00 * duration.getWeight());
+	}
+
+	/**
+	 * 연간(YEAR) 활동 지표를 기반으로 최종 등급(Grade)을 계산한다.
+	 *
+	 * <p>계산 절차:</p>
+	 * <ol>
+	 *   <li>연간 커밋 수, 커밋 라인 수, 스타 수, 팔로워 수를 추출</li>
+	 *   <li>{@link #calculatePercentile} 로 백분위(0~100)를 계산</li>
+	 *   <li>백분위 값이 {@code THRESHOLDS} 배열의 어느 구간에 속하는지 판별</li>
+	 *   <li>해당 구간의 {@code LEVELS} 값을 반환</li>
+	 *   <li>모든 구간에 해당하지 않으면 기본값 "C" 반환</li>
+	 * </ol>
+	 *
+	 * <p><b>특징</b>:</p>
+	 * <ul>
+	 *   <li>등급 산출은 연간(YEAR) 데이터만 사용</li>
+	 *   <li>퍼센타일 값이 낮을수록 더 높은 등급(S, A 등)을 부여</li>
+	 *   <li>퍼센타일 값이 높으면 낮은 등급(B, C 등)으로 매핑</li>
+	 * </ul>
+	 *
+	 * @param rankingParameters GitHub 활동 지표 (연간 데이터 포함)
+	 * @return 산출된 등급 문자열 ("S" ~ "C")
+	 */
+	private String calculateRankingGrade(RankingCalculatorParameters rankingParameters) {
+
+		double percentile = calculatePercentile(
+			rankingParameters.yearStats().commits(),
+			rankingParameters.yearStats().commitLines(),
+			rankingParameters.stars(),
+			rankingParameters.followers(),
+			RankingPeriod.YEAR);
+
 		for (int i = 0; i < THRESHOLDS.length; i++) {
 			if (percentile <= THRESHOLDS[i]) {
 				return LEVELS[i];
@@ -120,72 +174,53 @@ public class RankingCalculator {
 	}
 
 	/**
-	 * 특정 사용자의 활동 지표를 기반으로 랭킹 점수(포인트)를 계산합니다.
+	 * 활동 지표와 기간을 기반으로 백분위(Percentile, 0~100)를 계산한다.
 	 *
 	 * <p>계산 절차:</p>
 	 * <ol>
-	 *   <li>{@link #calculatePercentile(int, int, int, int)} 로 백분위(0~100)를 계산</li>
-	 *   <li>백분위를 역전(100 - percentile)하여 점수화
-	 *       <br/> → 활동이 많을수록 percentile ↓, 점수 ↑</li>
-	 *   <li>기본 배점(100,000)과 기간 가중치({@link RankingPeriod#getWeight()})를 곱해 최종 점수를 산출</li>
-	 * </ol>
-	 *
-	 * <p>예시:</p>
-	 * <ul>
-	 *   <li>percentile = 20, duration.weight = 4 (월간)
-	 *       → (100 - 20) * 100,000 * 4 = 32,000,000 점</li>
-	 *   <li>percentile = 80, duration.weight = 1 (주간)
-	 *       → (100 - 80) * 100,000 * 1 = 2,000,000 점</li>
-	 * </ul>
-	 *
-	 * @param commits     총 커밋 수
-	 * @param commitLines 총 커밋 라인 수
-	 * @param stars       총 star 개수
-	 * @param followers   팔로워 수
-	 * @param duration    점수를 산정할 기간 (주/월/년) 가중치
-	 * @return            산출된 랭킹 점수
-	 */
-	private long calculateRankingPoint(int commits, int commitLines, int stars, int followers, RankingPeriod duration) {
-
-		double percentile = calculatePercentile(commits, commitLines, stars, followers);
-
-		return (long)((100 - percentile) * 100_000 * duration.getWeight());
-	}
-
-	/**
-	 * 사용자의 활동 지표를 기반으로 백분위(0 ~ 100)를 계산합니다.
-	 *
-	 * <p>계산 방식:</p>
-	 * <ol>
-	 *   <li>각 항목(커밋 수, 커밋 라인 수, 스타, 팔로워)을 정규화
+	 *   <li>기간(duration)에 따라 커밋 수와 커밋 라인 수의 Median 기준값을 선택</li>
+	 *   <li>입력값(commits, commitLines, stars, followers)을 각 Median 값으로 정규화</li>
+	 *   <li>정규화된 값에 지표별 CDF 함수 적용
 	 *       <ul>
-	 *         <li>커밋 수, 스타, 팔로워 → {@link #exponentialCdf(double)} 로 변환</li>
-	 *         <li>커밋 라인 수 → {@link #logNormalCdf(double)} 로 변환</li>
+	 *         <li>커밋 수, 스타, 팔로워 → {@link #exponentialCdf(double)} (초기 활동량에 민감)</li>
+	 *         <li>커밋 라인 수 → {@link #logNormalCdf(double)} (큰 값의 영향 완화)</li>
 	 *       </ul>
 	 *   </li>
-	 *   <li>각 항목의 점수에 항목별 가중치({@code COMMITS_WEIGHT}, {@code COMMITS_LINES_WEIGHT}, …)를 곱함</li>
-	 *   <li>전체 가중치({@code TOTAL_WEIGHT})로 나누어 평균을 구함</li>
-	 *   <li>1에서 빼서 "상대 점수(rank)"로 변환 (활동 ↑ → rank ↑ → percentile ↓)</li>
-	 *   <li>rank를 0~100 범위의 백분위로 변환하여 반환</li>
+	 *   <li>지표별 점수에 가중치(COMMITS_WEIGHT, COMMITS_LINES_WEIGHT 등)를 곱하고 총합</li>
+	 *   <li>총합을 전체 가중치(TOTAL_WEIGHT)로 나누어 평균화</li>
+	 *   <li>1에서 빼서 rank 계산 (활동량 ↑ → rank ↑ → percentile ↓)</li>
+	 *   <li>rank를 0~100 범위로 변환하여 최종 백분위 반환</li>
 	 * </ol>
 	 *
-	 * <p>특징:</p>
+	 * <p><b>특징</b>:</p>
 	 * <ul>
-	 *   <li>활동량이 많을수록 percentile 값은 낮아짐 (즉, 상위 랭킹에 가까움)</li>
-	 *   <li>활동이 거의 없으면 percentile 값이 100에 가까워져 최하위 등급에 매핑됨</li>
+	 *   <li>퍼센타일 값이 낮을수록 활동 성과가 높음을 의미</li>
+	 *   <li>퍼센타일 값이 100에 가까울수록 활동이 적어 하위 그룹에 속함</li>
 	 * </ul>
 	 *
-	 * @param commits     총 커밋 수
-	 * @param commitLines 총 커밋 라인 수
+	 * @param commits     커밋 수
+	 * @param commitLines 커밋 라인 수
 	 * @param stars       스타 수
 	 * @param followers   팔로워 수
-	 * @return            계산된 백분위 (0 = 최고 성과, 100 = 최하위 성과)
+	 * @param duration    대상 기간 ({@link RankingPeriod})
+	 * @return 백분위 값 (0=최상위, 100=최하위)
 	 */
-	private double calculatePercentile(int commits, int commitLines, int stars, int followers) {
+	private double calculatePercentile(int commits, int commitLines, int stars, int followers, RankingPeriod duration) {
 
-		// 각 항목의 점수를 계산한 후 전체 가중치로 평균 → 1에서 빼면 "상대 점수 Percentile"
-		double rank = 1 - (COMMITS_WEIGHT * exponentialCdf(commits / COMMITS_MEDIAN) +
-			COMMITS_LINES_WEIGHT * logNormalCdf(commitLines / COMMITS_LINES_MEDIAN) +
+		double commitsMedian = switch (duration) {
+			case YEAR -> YEARLY_COMMITS_MEDIAN;
+			case MONTH -> MONTHLY_COMMITS_MEDIAN;
+			case WEEK -> WEEKLY_COMMITS_MEDIAN;
+		};
+
+		double commitLinesMedian = switch (duration) {
+			case YEAR -> YEARLY_COMMITS_LINES_MEDIAN;
+			case MONTH -> MONTHLY_COMMITS_LINES_MEDIAN;
+			case WEEK -> WEEKLY_COMMITS_LINES_MEDIAN;
+		};
+
+		double rank = 1 - (COMMITS_WEIGHT * exponentialCdf(commits / commitsMedian) +
+			COMMITS_LINES_WEIGHT * logNormalCdf(commitLines / commitLinesMedian) +
 			STARS_WEIGHT * exponentialCdf(stars / STARS_MEDIAN) +
 			FOLLOWERS_WEIGHT * exponentialCdf(followers / FOLLOWERS_MEDIAN)) / TOTAL_WEIGHT;
 
@@ -199,12 +234,12 @@ public class RankingCalculator {
 	 *
 	 * <p>특징:</p>
 	 * <ul>
-	 *   <li>작은 값의 변화에 민감하게 반응 → 초기 활동량에 빠르게 점수 상승</li>
-	 *   <li>큰 값으로 갈수록 점수 증가폭이 점차 둔화 → 과도한 활동량의 영향력 억제</li>
-	 *   <li>활동 초반의 “소수 정예”를 부각시키고 싶을 때 적합</li>
+	 *   <li>작은 입력값에 민감하게 반응 → 초기 활동량을 빠르게 점수화</li>
+	 *   <li>x가 커질수록 점증하지만 1에 수렴 → 과도한 활동량의 영향은 제한</li>
+	 *   <li>커밋 수, 스타 수, 팔로워 수와 같은 "소수의 증가가 의미 있는 지표"에 적합</li>
 	 * </ul>
 	 *
-	 * @param x 정규화된 입력 값 (예: commits / COMMITS_MEDIAN)
+	 * @param x 정규화된 입력 값 (예: commits / YEARLY_COMMITS_MEDIAN)
 	 * @return 0 ~ 1 범위의 CDF 값
 	 */
 	private double exponentialCdf(double x) {
@@ -218,12 +253,12 @@ public class RankingCalculator {
 	 *
 	 * <p>특징:</p>
 	 * <ul>
-	 *   <li>입력이 커질수록 1에 점근 → 극단적인 큰 값의 영향력을 제한</li>
-	 *   <li>중간 구간에서 점수가 점진적으로 증가하여 균형 있는 분포 제공</li>
-	 *   <li>커밋 라인 수처럼 값의 편차가 클 때 유용</li>
+	 *   <li>입력이 커질수록 1에 점근 → 큰 값일수록 영향력이 제한됨</li>
+	 *   <li>중간 구간에서 점진적으로 증가 → 분포가 큰 지표에서도 균형 있게 점수화</li>
+	 *   <li>커밋 라인 수와 같이 값의 편차가 큰 지표에 적합</li>
 	 * </ul>
 	 *
-	 * @param x 정규화된 입력 값 (예: commitLines / COMMITS_LINES_MEDIAN)
+	 * @param x 정규화된 입력 값 (예: commitLines / YEARLY_COMMITS_LINES_MEDIAN)
 	 * @return 0 ~ 1 범위의 CDF 값
 	 */
 	private double logNormalCdf(double x) {

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/ranking/RankingPeriod.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/ranking/RankingPeriod.java
@@ -7,10 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum RankingPeriod {
 
-	WEEK("week", 7),
-	MONTH("month", 31),
-	YEAR("year", 365);
+	WEEK("week", 1.0 / 52),
+	MONTH("month", 1.0 / 12),
+	YEAR("year", 1.0);
 
 	private final String value;
-	private final long weight;
+	private final double weight;
 }

--- a/Moyoy-Domain/src/test/java/com/moyoy/domain/ranking/RankingCalculatorTest.java
+++ b/Moyoy-Domain/src/test/java/com/moyoy/domain/ranking/RankingCalculatorTest.java
@@ -1,8 +1,62 @@
 package com.moyoy.domain.ranking;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-/// TODO: Ranking 계산기 분기처리 후 테스트 작성
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.moyoy.domain.ranking.dto.RankingCalculatorParameters;
+import com.moyoy.domain.ranking.dto.RankingCalculatorResult;
+
 class RankingCalculatorTest {
 
+	private RankingCalculator rankingCalculator;
+
+	@BeforeEach
+	void setUp() {
+		rankingCalculator = new RankingCalculator();
+	}
+
+	@Test
+	void 주간_월간_연간_점수와_등급을_계산한다() {
+
+		// given
+		RankingCalculatorParameters params = new RankingCalculatorParameters(
+			50,
+			100,
+			new RankingCalculatorParameters.CommitStatsSummary(10, 500), // week
+			new RankingCalculatorParameters.CommitStatsSummary(40, 2000), // month
+			new RankingCalculatorParameters.CommitStatsSummary(200, 10000) // year
+		);
+
+		// when
+		RankingCalculatorResult result = rankingCalculator.calculate(params);
+
+		// then
+		assertThat(result.weekRankingPoint()).isGreaterThan(0);
+		assertThat(result.monthRankingPoint()).isGreaterThan(0);
+		assertThat(result.yearRankingPoint()).isGreaterThan(0);
+
+		assertThat(result.rankingGrade()).isIn("S", "A+", "A", "A-", "B+", "B", "B-", "C+", "C");
+	}
+
+	@Test
+	void 활동이_없으면_최하위_등급을_부여한다() {
+
+		// given
+		RankingCalculatorParameters params = new RankingCalculatorParameters(
+			0, 0,
+			new RankingCalculatorParameters.CommitStatsSummary(0, 0),
+			new RankingCalculatorParameters.CommitStatsSummary(0, 0),
+			new RankingCalculatorParameters.CommitStatsSummary(0, 0));
+
+		// when
+		RankingCalculatorResult result = rankingCalculator.calculate(params);
+
+		// then
+		assertThat(result.weekRankingPoint()).isEqualTo(0);
+		assertThat(result.monthRankingPoint()).isEqualTo(0);
+		assertThat(result.yearRankingPoint()).isEqualTo(0);
+		assertThat(result.rankingGrade()).isEqualTo("C");
+	}
 }


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #159

<br />

## 🔎 PR 내용

- `RankingCalculator`의 랭킹 산출 방식을 리팩터링했습니다.
- 기존에는 모든 기간(주/월/년)에 동일한 Median 값을 사용했으나,
  연간 기준 Median을 정의하고 이를 12, 52로 나눈 값을 각각 월간/주간 Median으로 적용했습니다.
- 점수 산출 시 `duration.getWeight()`를 활용하여 기간별 점수를 상대적으로 보정하도록 변경했습니다.
- 기존에 21564236436 처럼 과하게 큰 값의 랭킹을 100만 미만으로 들어오게 조정했습니다.