### PR TITLE
fix: Add missing TTL when updating cache

### DIFF
--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/redis/cache/github_follow/GithubFollowCacheStore.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/redis/cache/github_follow/GithubFollowCacheStore.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Component;
 public class GithubFollowCacheStore {
 
 	private static final String FOLLOW_CACHE_NAME = "followSnapshot";
+	private static final String FOLLOW_CACHE_TTL = "900";
 
 	private final CacheManager cacheManager;
 	private final StringRedisTemplate stringRedisTemplate;
@@ -51,12 +52,11 @@ public class GithubFollowCacheStore {
 			String script =
 					"local current = redis.call('GET', KEYS[1]) " +
 							"if current == false then " +
-							"  redis.call('SET', KEYS[1], ARGV[1]) " +
 							"  return 1 " +
 							"end " +
 							"local currentVersion = cjson.decode(current).version " +
 							"if currentVersion == tonumber(ARGV[2]) then " +
-							"  redis.call('SET', KEYS[1], ARGV[1]) " +
+							"  redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[3]) " +
 							"  return 1 " +
 							"else " +
 							"  return 0 " +
@@ -66,10 +66,11 @@ public class GithubFollowCacheStore {
 					RedisScript.of(script, Long.class),
 					Collections.singletonList(FOLLOW_CACHE_NAME + "::" + userId),
 					jsonString,
-					expectedVersion.toString()
+					expectedVersion.toString(),
+					FOLLOW_CACHE_TTL
 			);
 
-			log.info("{} 낙관락 결과", result);
+			log.info("{}의 캐시 보정 | 낙관락 결과 = {}", userId, result);
 			return result == 1;
 
 		} catch (JsonProcessingException e) {


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #166 

## 🔎 PR 내용

### 문제상황
- Redis에서 `SET` 명령어 사용 시 기존 키의 TTL이 제거되어 영구 키로 변경되는 문제 발생
- 캐시 보정 작업 후, 캐시가 만료되지 않음

해당 문제로 인해, TTL이 만료되지 않아, 사용자의 맞팔 탐지기 조회 시점에 데이터 강제 갱신이 되지 않는 문제를 수정했습니다.