### PR TITLE
Feat: 요청글 수동 마감 기능 추가

### DIFF
--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
@@ -1,5 +1,7 @@
 package com.moyoy.api.pr_review.application;
 
+import java.time.LocalDateTime;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -20,8 +22,6 @@ import com.moyoy.infra.database.mysql.pr_review.response.PrReviewDetailData;
 import com.moyoy.infra.database.mysql.pr_review.response.PrReviewSummaryData;
 
 import com.moyoy.common.page.SliceResult;
-
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
@@ -7,10 +7,7 @@ import org.springframework.stereotype.Service;
 import com.moyoy.api.pr_review.application.request.PrReviewCreateData;
 import com.moyoy.api.pr_review.application.request.PrReviewUpdateData;
 import com.moyoy.api.pr_review.application.request.SearchConditionData;
-import com.moyoy.api.pr_review.application.response.PrReviewCreateResult;
-import com.moyoy.api.pr_review.application.response.PrReviewDetailResult;
-import com.moyoy.api.pr_review.application.response.PrReviewListResult;
-import com.moyoy.api.pr_review.application.response.PrReviewUpdateResult;
+import com.moyoy.api.pr_review.application.response.*;
 
 import com.moyoy.domain.pr_review.PrReview;
 import com.moyoy.domain.pr_review.PrReviewRepository;
@@ -90,5 +87,21 @@ public class PrReviewService {
 		}
 
 		prReviewRepository.deleteById(reviewId);
+	}
+
+	public PrReviewCloseResult closePrReview(Long reviewId, Long userId) {
+
+		PrReview prReview = prReviewRepository.findById(reviewId)
+			.orElseThrow(PrReviewNotFoundException::new);
+
+		if (!prReview.getUserId().equals(userId)) {
+			throw new PrReviewEditForbiddenException();
+		}
+
+		prReview.close();
+
+		Long closedReviewId = prReviewRepository.save(prReview).getId();
+
+		return new PrReviewCloseResult(closedReviewId);
 	}
 }

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
@@ -21,6 +21,8 @@ import com.moyoy.infra.database.mysql.pr_review.response.PrReviewSummaryData;
 
 import com.moyoy.common.page.SliceResult;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class PrReviewService {
@@ -89,7 +91,7 @@ public class PrReviewService {
 		prReviewRepository.deleteById(reviewId);
 	}
 
-	public PrReviewCloseResult closePrReview(Long reviewId, Long userId) {
+	public PrReviewCloseResult closePrReview(Long reviewId, Long userId, LocalDateTime eventTime) {
 
 		PrReview prReview = prReviewRepository.findById(reviewId)
 			.orElseThrow(PrReviewNotFoundException::new);
@@ -98,7 +100,7 @@ public class PrReviewService {
 			throw new PrReviewEditForbiddenException();
 		}
 
-		prReview.close();
+		prReview.close(eventTime);
 
 		Long closedReviewId = prReviewRepository.save(prReview).getId();
 

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/response/PrReviewCloseResult.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/response/PrReviewCloseResult.java
@@ -1,0 +1,8 @@
+package com.moyoy.api.pr_review.application.response;
+
+public record PrReviewCloseResult(
+	Long prReviewId) {
+	public static PrReviewCloseResult from(Long reviewId) {
+		return new PrReviewCloseResult(reviewId);
+	}
+}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/presentation/PrReviewController.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/presentation/PrReviewController.java
@@ -96,4 +96,16 @@ public class PrReviewController {
 
 		return ResponseEntity.ok(ApiResponse.noContent());
 	}
+
+	@PatchMapping("/pr-reviews{pr-reviewId}/status")
+	public ResponseEntity<ApiResponse<PrReviewRedirectResponse>> close(
+		@LoginUserId Long userId,
+		@PathVariable("pr-reviewId") Long reviewId) {
+
+		PrReviewCloseResult result = prReviewService.closePrReview(reviewId, userId);
+
+		PrReviewRedirectResponse response = PrReviewRedirectResponse.from(result);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
 }

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/presentation/PrReviewController.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/presentation/PrReviewController.java
@@ -1,5 +1,7 @@
 package com.moyoy.api.pr_review.presentation;
 
+import java.time.LocalDateTime;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
@@ -20,8 +22,6 @@ import com.moyoy.api.pr_review.presentation.response.PrReviewListResponse;
 import com.moyoy.api.pr_review.presentation.response.PrReviewRedirectResponse;
 
 import jakarta.validation.Valid;
-
-import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/v1")

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/presentation/PrReviewController.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/presentation/PrReviewController.java
@@ -21,6 +21,8 @@ import com.moyoy.api.pr_review.presentation.response.PrReviewRedirectResponse;
 
 import jakarta.validation.Valid;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
@@ -102,7 +104,7 @@ public class PrReviewController {
 		@LoginUserId Long userId,
 		@PathVariable("pr-reviewId") Long reviewId) {
 
-		PrReviewCloseResult result = prReviewService.closePrReview(reviewId, userId);
+		PrReviewCloseResult result = prReviewService.closePrReview(reviewId, userId, LocalDateTime.now());
 
 		PrReviewRedirectResponse response = PrReviewRedirectResponse.from(result);
 

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/presentation/response/PrReviewRedirectResponse.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/presentation/response/PrReviewRedirectResponse.java
@@ -1,17 +1,20 @@
 package com.moyoy.api.pr_review.presentation.response;
 
+import com.moyoy.api.pr_review.application.response.PrReviewCloseResult;
 import com.moyoy.api.pr_review.application.response.PrReviewCreateResult;
 import com.moyoy.api.pr_review.application.response.PrReviewUpdateResult;
 
 public record PrReviewRedirectResponse(
 	Long prReviewId) {
 	public static PrReviewRedirectResponse from(PrReviewCreateResult result) {
-		return new PrReviewRedirectResponse(
-			result.prReviewId());
+		return new PrReviewRedirectResponse(result.prReviewId());
 	}
 
 	public static PrReviewRedirectResponse from(PrReviewUpdateResult result) {
-		return new PrReviewRedirectResponse(
-			result.prReviewId());
+		return new PrReviewRedirectResponse(result.prReviewId());
+	}
+
+	public static PrReviewRedirectResponse from(PrReviewCloseResult result) {
+		return new PrReviewRedirectResponse(result.prReviewId());
 	}
 }

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReview.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReview.java
@@ -49,4 +49,9 @@ public class PrReview {
 		this.content = content.content();
 		this.closedAt = content.closedAt();
 	}
+
+	public void close() {
+		this.status = Status.CLOSED;
+		this.closedAt = LocalDateTime.now();
+	}
 }

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReview.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReview.java
@@ -50,8 +50,15 @@ public class PrReview {
 		this.closedAt = content.closedAt();
 	}
 
-	public void close() {
+	public void close(LocalDateTime eventTime) {
+		if (this.status == Status.CLOSED) {
+			if (eventTime.isBefore(this.closedAt)) {
+				this.closedAt = eventTime;
+			}
+			return;
+		}
+
 		this.status = Status.CLOSED;
-		this.closedAt = LocalDateTime.now();
+		this.closedAt = eventTime;
 	}
 }

--- a/Moyoy-Domain/src/test/java/com/moyoy/domain/pr_review/PrReviewTest.java
+++ b/Moyoy-Domain/src/test/java/com/moyoy/domain/pr_review/PrReviewTest.java
@@ -1,0 +1,105 @@
+package com.moyoy.domain.pr_review;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PrReviewTest {
+
+	@Nested
+	@DisplayName("PR 리뷰 요청글 마감")
+	class ClosePrReview {
+
+		@Test
+		void OPEN_상태의_요청글을_마감한다() {
+
+			// given
+			LocalDateTime eventTime = LocalDateTime.of(2025, 11, 13, 15, 34);
+
+			PrReview prReview = PrReview.builder()
+				.id(1L)
+				.userId(10L)
+				.title("곧 마감될 글")
+				.position(Position.BACKEND)
+				.prUrl("https://github.com/Mo-yoy/Moyoy-Backend/pull/888")
+				.content("본문은 10자를 넘어야 하니깐")
+				.hitCount(10)
+				.status(Status.OPEN)
+				.adopted(false)
+				.createdAt(LocalDateTime.of(2025, 11, 6, 15, 40))
+				.closedAt(LocalDateTime.of(2025, 11, 13, 15, 40))
+				.build();
+
+			// when
+			prReview.close(eventTime);
+
+			// then
+			assertThat(prReview.getStatus()).isEqualTo(Status.CLOSED);
+			assertThat(prReview.getClosedAt()).isEqualTo(eventTime);
+		}
+
+		@Test
+		@DisplayName("수동 마감이 경합으로 자동 마감보다 늦게 처리됐을 때, 수동 마감 요청 시간을 우선한다.")
+		void CLOSED_상태에서_더_이른_시각의_요청이_오면_그_시간으로_갱신한다() {
+
+			// given
+			LocalDateTime originalClosedAt = LocalDateTime.of(2025, 11, 13, 15, 40);
+			LocalDateTime eventTime = LocalDateTime.of(2025, 11, 13, 15, 34);
+
+			PrReview prReview = PrReview.builder()
+				.id(2L)
+				.userId(10L)
+				.title("자동 마감 처리된 글")
+				.position(Position.BACKEND)
+				.prUrl("https://github.com/Mo-yoy/Moyoy-Backend/pull/777")
+				.content("아니 마감되기 전에 수동마감 눌렀는데, 작업이 밀려서 자동마감 처리 됐다구욧")
+				.hitCount(20)
+				.status(Status.CLOSED)
+				.adopted(false)
+				.createdAt(LocalDateTime.of(2025, 11, 5, 11, 20))
+				.closedAt(originalClosedAt)
+				.build();
+
+			// when
+			prReview.close(eventTime);
+
+			// then
+			assertThat(prReview.getStatus()).isEqualTo(Status.CLOSED);
+			assertThat(prReview.getClosedAt()).isEqualTo(eventTime);
+		}
+
+		@Test
+		@DisplayName("이미 마감된 글에 수동 마감을 시도하면, 아무 작업도 안 한다.")
+		void CLOSED_상태에서_더_늦은_시각의_요청이_오면_마감_시각을_유지한다() {
+
+			// given
+			LocalDateTime originalClosedAt = LocalDateTime.of(2025, 11, 13, 15, 34); // 자동마감이 먼저 처리한 시각
+			LocalDateTime eventTime = LocalDateTime.of(2025, 11, 13, 15, 40); // 수동마감 시도.
+
+			PrReview prReview = PrReview.builder()
+				.id(3L)
+				.userId(10L)
+				.title("이미 마감된 글")
+				.position(Position.BACKEND)
+				.prUrl("https://github.com/Mo-yoy/Moyoy-Backend/pull/666")
+				.content("원래는 예외를 터뜨려야 하나 했는데, 나중에 자동마감 배치에서 예외 터지면 곤란해서 그냥 nothing to do")
+				.hitCount(5)
+				.status(Status.CLOSED)
+				.adopted(false)
+				.createdAt(LocalDateTime.of(2025, 11, 6, 15, 34))
+				.closedAt(originalClosedAt)
+				.build();
+
+			// when
+			prReview.close(eventTime);
+
+			// then
+			assertThat(prReview.getStatus()).isEqualTo(Status.CLOSED);
+			assertThat(prReview.getClosedAt()).isEqualTo(originalClosedAt);
+		}
+	}
+}


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #169 

## ☑️ 완료 태스크
- [x] 수동 마감 기능 추가
- [x] 테스트 코드 작성

<br />

## 🔎 PR 내용
PR 리뷰 요청글 등록 시 설정한 마감 시각이 되기 전에 미리 수동 마감할 수 있도록 하는 기능 추가했습니다.
<br />

나중에 자동 마감 배치가 추가될 텐데
이때 만약 서로 근소한 차이를 두고 자동 마감 배치와 수동 마감 작업이 들어와 경합이 발생할 수 있으므로,
이미 (자동 마감 배치로) 마감 상태인 요청글에 수동 마감 요청이 후속으로 들어오면
수동 마감 요청이 들어온 시각이 마감 시각보다 이르면 수동 마감 시각을 우선하여 갱신하는 쪽으로 했습니다.

**요약: 수동 · 자동 경합 시, 수동 마감 시각을 우선한다.**
<br />

이런 상황을 고려해서, 이미 마감된 글에 수동 마감 API 호출이 되더라도 예외 처리되진 않습니다.
자동 마감 배치에서 예외가 발생하면 곤란하기 때문에, 예외 대신 아무 작업도 하지 않는 방향으로 했습니다.

<br />
