### PR TITLE
Refactor: 요청글 기본 상태 변경

### DIFF
--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewSummary.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewSummary.java
@@ -7,6 +7,7 @@ import com.moyoy.infra.database.mysql.pr_review.response.PrReviewSummaryData;
 public record PrReviewSummary(
 	String profileImageUrl,
 	String username,
+	String status,
 	String position,
 	String title,
 	int hitCount,
@@ -15,6 +16,7 @@ public record PrReviewSummary(
 		return new PrReviewSummary(
 			data.profileImageUrl(),
 			data.username(),
+			data.status().name(),
 			data.position().toString(),
 			data.title(),
 			data.hitCount(),

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewSummary.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewSummary.java
@@ -17,7 +17,7 @@ public record PrReviewSummary(
 			data.profileImageUrl(),
 			data.username(),
 			data.status().name(),
-			data.position().toString(),
+			data.position().name(),
 			data.title(),
 			data.hitCount(),
 			data.createdAt());

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/response/PrReviewDetailResult.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/response/PrReviewDetailResult.java
@@ -20,7 +20,7 @@ public record PrReviewDetailResult(
 
 	public static PrReviewDetailResult from(PrReviewDetailData data, boolean isWriter) {
 		return new PrReviewDetailResult(
-			data.status().getValue(),
+			data.status().name(),
 			isWriter,
 			data.adopted(),
 			data.profileImageUrl(),

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/presentation/request/PrReviewListRequest.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/presentation/request/PrReviewListRequest.java
@@ -4,17 +4,19 @@ import com.moyoy.api.pr_review.application.request.SearchConditionData;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record PrReviewListRequest(
-	@NotBlank @Pattern(regexp = "open|closed") String status,
+	@Pattern(regexp = "open|closed") String status,
 	String order,
 	String position,
 	@Min(0) Long lastReviewId,
 	@Min(1) @Max(100) Integer size) {
 
 	public PrReviewListRequest {
+		if (status == null || status.isBlank())
+			status = null;
+
 		if (order == null)
 			order = "createdAt-desc";
 

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/Status.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/Status.java
@@ -16,6 +16,10 @@ public enum Status {
 	private final String value;
 
 	public static Status from(String value) {
+		if (value == null) {
+			return null;
+		}
+
 		return Arrays.stream(Status.values())
 			.filter(status -> status.name().equalsIgnoreCase(value) || status.value.equals(value))
 			.findFirst()

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewQueryRepositoryImpl.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewQueryRepositoryImpl.java
@@ -33,8 +33,10 @@ public class PrReviewQueryRepositoryImpl implements PrReviewQueryRepository {
 	public SliceResult<PrReviewSummaryData> findAll(PrReviewQueryConditionData condition) {
 
 		BooleanBuilder builder = new BooleanBuilder();
-		builder.and(prReviewEntity.status.eq(condition.status()));
 
+		if (condition.status() != null) {
+			builder.and(prReviewEntity.status.eq(condition.status()));
+		}
 		if (condition.userId() != null) {
 			builder.and(prReviewEntity.userId.eq(condition.userId()));
 		}

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewQueryRepositoryImpl.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewQueryRepositoryImpl.java
@@ -54,6 +54,7 @@ public class PrReviewQueryRepositoryImpl implements PrReviewQueryRepository {
 				PrReviewSummaryData.class,
 				userEntity.profileImgUrl,
 				userEntity.username,
+				prReviewEntity.status,
 				prReviewEntity.position,
 				prReviewEntity.title,
 				prReviewEntity.hitCount,

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/response/PrReviewSummaryData.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/response/PrReviewSummaryData.java
@@ -3,10 +3,12 @@ package com.moyoy.infra.database.mysql.pr_review.response;
 import java.time.LocalDateTime;
 
 import com.moyoy.domain.pr_review.Position;
+import com.moyoy.domain.pr_review.Status;
 
 public record PrReviewSummaryData(
 	String profileImageUrl,
 	String username,
+	Status status,
 	Position position,
 	String title,
 	int hitCount,


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #173

## ☑️ 완료 태스크
- [x] `status` 파라미터 `@NotBlank` 제약 삭제
- [x] `status`값이 null이라면, 모든 상태의 요청글을 가져오도록 변경
- [x] 전체 목록 조회 API 응답에 요청글 상태 `status` 필드도 추가로 전달

<br />

## 🔎 PR 내용

<img width="500" alt="image" src="https://github.com/user-attachments/assets/3306bae9-9ad0-446e-b7cd-8a6a79e1df86" />

원래 PR 리뷰 요청글은 `open` 혹은 `closed` 상태로 나뉘어서
전체 목록 조회 시 상태 파라미터 값을 전달하도록 되어있었는데,

@Yeonseo-Jo 연서랑 의논하면서 이와 관련한 변경 사항이 나왔습니다.
1. `open`과 `closed`를 모두 보여주는 게 있으면 좋겠다.
2. 모요이 서비스 기본 홈 화면 `PR 리뷰 요청` 탭에서는 모두 섞은 걸 보여주자.
3. 요청글 전체 목록 조회에선 프론트에서 상태값을 필터링하겠다.
<br />


### 1️⃣ `status` 값 null일 경우, 모든 상태 가져오기
기존에 요청글 목록 조회 시, 쿼리 파라미터로 status값을 `open`이나 `closed` 둘 중 하나 넘겨주는 형식이었는데,
파라미터에 `status` 값이 존재하지 않으면 `open` + `closed`를 모두 보여주도록 변경했습니다.

3가지 경우 스크린샷은 하단에 배치해놨습니다.
<br />

### 2️⃣ 모든 상태값을 받았을 때, 상태 구별이 가능하도록 `status` 추가 전달
<img width="730" alt="image" src="https://github.com/user-attachments/assets/e170c6a0-e096-4c75-9e57-925f72ad0d8b" />

기존엔 특정 `status`를 조회 API 호출 시에 쿼리 파라미터로 넘겨주었기에 따로 반환할 필요가 없었으나,
모든 상태의 요청글을 조회할 시 각 요청글의 상태를 구별할 수 있도록 추가로 반환하도록 했습니다.



변경 사항은 `PR 리뷰 요청글 전체 조회`와 `내 리뷰 요청글 전체 조회`에 모두 반영됩니다.
<br />

## 📷 스크린샷
### 1️⃣ 상태값에 아무 필터링 없을 때
<img width="730" alt="image" src="https://github.com/user-attachments/assets/f7f35c5b-87d6-4b41-a637-1845011ca7c9" />


### 2️⃣ OPEN 상태 요청글 전체 조회
<img width="730" alt="image" src="https://github.com/user-attachments/assets/a17c1fcd-51d9-4a52-b303-960b151e84e3" />


### 3️⃣ CLOSED 상태 요청글 전체 조회
<img width="730" alt="image" src="https://github.com/user-attachments/assets/6073aa4d-b25f-4dce-81c2-abb3b14bab37" />


<!-- 팀원들이 이해할 수 있게 구현한 화면을 보여주세요 -->