### PR TITLE
Feat: 요청글 조회수 관리 v1

### DIFF
--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewAsyncService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewAsyncService.java
@@ -1,0 +1,40 @@
+package com.moyoy.api.pr_review.application;
+
+import java.time.LocalDateTime;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.moyoy.domain.pr_review.PrReviewHit;
+import com.moyoy.domain.pr_review.PrReviewHitRepository;
+import com.moyoy.domain.pr_review.PrReviewRepository;
+import com.moyoy.domain.pr_review.dto.PrReviewHitCreate;
+
+@Service
+@RequiredArgsConstructor
+public class PrReviewAsyncService {
+
+	private final PrReviewRepository prReviewRepository;
+	private final PrReviewHitRepository prReviewHitRepository;
+
+	@Async("hitsExecutor")
+	@Transactional
+	public void increaseHitAsync(Long reviewId, Long userId) {
+		/// 해당 트랜잭션이 실패하면, 후처리를 할 것인가.
+
+		LocalDateTime now = LocalDateTime.now();
+
+		PrReviewHit hit = prReviewHitRepository.findOrCreate(
+			PrReviewHit.create(new PrReviewHitCreate(reviewId, userId, now)));
+
+		if (!hit.canIncrease(now))
+			return;
+
+		prReviewRepository.increaseHitCount(reviewId);
+
+		prReviewHitRepository.updateLastIncreasedAt(hit.getId(), now);
+	}
+}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
@@ -1,10 +1,18 @@
 package com.moyoy.api.pr_review.application;
 
+import java.time.LocalDateTime;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.moyoy.api.pr_review.application.request.PrReviewCreateData;
 import com.moyoy.api.pr_review.application.request.PrReviewUpdateData;
 import com.moyoy.api.pr_review.application.request.SearchConditionData;
 import com.moyoy.api.pr_review.application.response.*;
-import com.moyoy.common.page.SliceResult;
+
 import com.moyoy.domain.pr_review.PrReview;
 import com.moyoy.domain.pr_review.PrReviewHit;
 import com.moyoy.domain.pr_review.PrReviewHitRepository;
@@ -13,15 +21,12 @@ import com.moyoy.domain.pr_review.dto.PrReviewHitCreate;
 import com.moyoy.domain.pr_review.error.PrReviewDeleteForbiddenException;
 import com.moyoy.domain.pr_review.error.PrReviewEditForbiddenException;
 import com.moyoy.domain.pr_review.error.PrReviewNotFoundException;
+
 import com.moyoy.infra.database.mysql.pr_review.PrReviewQueryRepository;
 import com.moyoy.infra.database.mysql.pr_review.response.PrReviewDetailData;
 import com.moyoy.infra.database.mysql.pr_review.response.PrReviewSummaryData;
-import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import com.moyoy.common.page.SliceResult;
 
 @Service
 @RequiredArgsConstructor
@@ -118,19 +123,13 @@ public class PrReviewService {
 		LocalDateTime now = LocalDateTime.now();
 
 		PrReviewHit hit = prReviewHitRepository.saveIfNotExist(
-			PrReviewHit.create(new PrReviewHitCreate(reviewId, userId, now))
-		);
+			PrReviewHit.create(new PrReviewHitCreate(reviewId, userId, now)));
 
-		if (!hit.canIncrease(now)) return;
+		if (!hit.canIncrease(now))
+			return;
 
-		PrReview review = prReviewRepository.findById(reviewId)
-			.orElseThrow(PrReviewNotFoundException::new);
+		prReviewRepository.increaseHitCount(reviewId);
 
-		/// TODO: 동시성 문제 해결 필요
-		review.increaseHitCount();
-		prReviewRepository.save(review);
-
-		/// TODO: 마찬가지
 		hit.updateLastTime(now);
 		prReviewHitRepository.updateLastIncreasedAt(hit.getId(), now);
 	}

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
@@ -122,7 +122,7 @@ public class PrReviewService {
 
 		LocalDateTime now = LocalDateTime.now();
 
-		PrReviewHit hit = prReviewHitRepository.saveIfNotExist(
+		PrReviewHit hit = prReviewHitRepository.findOrCreate(
 			PrReviewHit.create(new PrReviewHitCreate(reviewId, userId, now)));
 
 		if (!hit.canIncrease(now))

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
@@ -4,9 +4,7 @@ import java.time.LocalDateTime;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.moyoy.api.pr_review.application.request.PrReviewCreateData;
 import com.moyoy.api.pr_review.application.request.PrReviewUpdateData;
@@ -14,10 +12,8 @@ import com.moyoy.api.pr_review.application.request.SearchConditionData;
 import com.moyoy.api.pr_review.application.response.*;
 
 import com.moyoy.domain.pr_review.PrReview;
-import com.moyoy.domain.pr_review.PrReviewHit;
 import com.moyoy.domain.pr_review.PrReviewHitRepository;
 import com.moyoy.domain.pr_review.PrReviewRepository;
-import com.moyoy.domain.pr_review.dto.PrReviewHitCreate;
 import com.moyoy.domain.pr_review.error.PrReviewDeleteForbiddenException;
 import com.moyoy.domain.pr_review.error.PrReviewEditForbiddenException;
 import com.moyoy.domain.pr_review.error.PrReviewNotFoundException;
@@ -32,10 +28,10 @@ import com.moyoy.common.page.SliceResult;
 @RequiredArgsConstructor
 public class PrReviewService {
 
-	private final PrReviewService self;
+	private final PrReviewAsyncService prReviewAsyncService;
+
 	private final PrReviewRepository prReviewRepository;
 	private final PrReviewQueryRepository prReviewQueryRepository;
-	private final PrReviewHitRepository prReviewHitRepository;
 
 	public PrReviewListResult getPrReviewList(SearchConditionData condition) {
 
@@ -53,7 +49,7 @@ public class PrReviewService {
 
 		/// TODO: 조회수 관리 (v1: 브릿지 테이블, v2: Redis, v3: Redis 기록/누적조회 일괄 업데이트, v4: hyperloglog/누적조회 일괄 업데이트)
 		///  특히 조회수 증가는 도메인 서비스인데, 뷰목적 dto 뿐아니라 entity로 도메인도 가져와야함.
-		self.increaseHitAsync(reviewId, userId);
+		prReviewAsyncService.increaseHitAsync(reviewId, userId);
 
 		return PrReviewDetailResult.from(data, isWriter);
 	}
@@ -113,23 +109,5 @@ public class PrReviewService {
 		Long closedReviewId = prReviewRepository.save(prReview).getId();
 
 		return new PrReviewCloseResult(closedReviewId);
-	}
-
-	@Async("hitsExecutor")
-	@Transactional
-	public void increaseHitAsync(Long reviewId, Long userId) {
-		/// 해당 트랜잭션이 실패하면, 후처리를 할 것인가.
-
-		LocalDateTime now = LocalDateTime.now();
-
-		PrReviewHit hit = prReviewHitRepository.findOrCreate(
-			PrReviewHit.create(new PrReviewHitCreate(reviewId, userId, now)));
-
-		if (!hit.canIncrease(now))
-			return;
-
-		prReviewRepository.increaseHitCount(reviewId);
-
-		prReviewHitRepository.updateLastIncreasedAt(hit.getId(), now);
 	}
 }

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
@@ -1,34 +1,36 @@
 package com.moyoy.api.pr_review.application;
 
-import java.time.LocalDateTime;
-
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
-
 import com.moyoy.api.pr_review.application.request.PrReviewCreateData;
 import com.moyoy.api.pr_review.application.request.PrReviewUpdateData;
 import com.moyoy.api.pr_review.application.request.SearchConditionData;
 import com.moyoy.api.pr_review.application.response.*;
-
+import com.moyoy.common.page.SliceResult;
 import com.moyoy.domain.pr_review.PrReview;
+import com.moyoy.domain.pr_review.PrReviewHit;
+import com.moyoy.domain.pr_review.PrReviewHitRepository;
 import com.moyoy.domain.pr_review.PrReviewRepository;
+import com.moyoy.domain.pr_review.dto.PrReviewHitCreate;
 import com.moyoy.domain.pr_review.error.PrReviewDeleteForbiddenException;
 import com.moyoy.domain.pr_review.error.PrReviewEditForbiddenException;
 import com.moyoy.domain.pr_review.error.PrReviewNotFoundException;
-
 import com.moyoy.infra.database.mysql.pr_review.PrReviewQueryRepository;
 import com.moyoy.infra.database.mysql.pr_review.response.PrReviewDetailData;
 import com.moyoy.infra.database.mysql.pr_review.response.PrReviewSummaryData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.moyoy.common.page.SliceResult;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class PrReviewService {
 
+	private final PrReviewService self;
 	private final PrReviewRepository prReviewRepository;
 	private final PrReviewQueryRepository prReviewQueryRepository;
+	private final PrReviewHitRepository prReviewHitRepository;
 
 	public PrReviewListResult getPrReviewList(SearchConditionData condition) {
 
@@ -44,8 +46,9 @@ public class PrReviewService {
 
 		boolean isWriter = data.userId().equals(userId);
 
-		/// TODO 2. 조회수 증가 관리 (중복 증가 방지 조사 후 적용)
+		/// TODO: 조회수 관리 (v1: 브릿지 테이블, v2: Redis, v3: Redis 기록/누적조회 일괄 업데이트, v4: hyperloglog/누적조회 일괄 업데이트)
 		///  특히 조회수 증가는 도메인 서비스인데, 뷰목적 dto 뿐아니라 entity로 도메인도 가져와야함.
+		self.increaseHitAsync(reviewId, userId);
 
 		return PrReviewDetailResult.from(data, isWriter);
 	}
@@ -105,5 +108,30 @@ public class PrReviewService {
 		Long closedReviewId = prReviewRepository.save(prReview).getId();
 
 		return new PrReviewCloseResult(closedReviewId);
+	}
+
+	@Async("hitsExecutor")
+	@Transactional
+	public void increaseHitAsync(Long reviewId, Long userId) {
+		/// 해당 트랜잭션이 실패하면, 후처리를 할 것인가.
+
+		LocalDateTime now = LocalDateTime.now();
+
+		PrReviewHit hit = prReviewHitRepository.saveIfNotExist(
+			PrReviewHit.create(new PrReviewHitCreate(reviewId, userId, now))
+		);
+
+		if (!hit.canIncrease(now)) return;
+
+		PrReview review = prReviewRepository.findById(reviewId)
+			.orElseThrow(PrReviewNotFoundException::new);
+
+		/// TODO: 동시성 문제 해결 필요
+		review.increaseHitCount();
+		prReviewRepository.save(review);
+
+		/// TODO: 마찬가지
+		hit.updateLastTime(now);
+		prReviewHitRepository.updateLastIncreasedAt(hit.getId(), now);
 	}
 }

--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
@@ -130,7 +130,6 @@ public class PrReviewService {
 
 		prReviewRepository.increaseHitCount(reviewId);
 
-		hit.updateLastTime(now);
 		prReviewHitRepository.updateLastIncreasedAt(hit.getId(), now);
 	}
 }

--- a/Moyoy-Api/src/main/java/com/moyoy/api/support/config/AsyncConfig.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/support/config/AsyncConfig.java
@@ -24,4 +24,18 @@ public class AsyncConfig {
 		executor.initialize();
 		return executor;
 	}
+
+	@Bean(name = "hitsExecutor")
+	public Executor hitsExecutor() {
+
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+		executor.setCorePoolSize(3);
+		executor.setMaxPoolSize(3);
+		executor.setQueueCapacity(300);
+		executor.setThreadNamePrefix("PrReviewHits-");
+
+		executor.initialize();
+		return executor;
+	}
 }

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReview.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReview.java
@@ -23,10 +23,6 @@ public class PrReview {
 	private LocalDateTime createdAt;
 	private LocalDateTime closedAt;
 
-	public void increaseHitCount() {
-		this.hitCount++;
-	} // TODO
-
 	public static PrReview create(PrReviewCreate prReviewCreate) {
 		return new PrReview(
 			null,

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHit.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHit.java
@@ -1,0 +1,22 @@
+package com.moyoy.domain.pr_review;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PrReviewHit {
+    private Long id;
+    private Long prReviewId;
+    private Long userId;
+    private LocalDateTime lastIncreasedAt;
+
+    private static final Duration TTL = Duration.ofHours(1);
+
+    public boolean canIncrease(LocalDateTime now) {
+        return lastIncreasedAt.plus(TTL).isBefore(now);
+    }
+}

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHit.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHit.java
@@ -1,5 +1,6 @@
 package com.moyoy.domain.pr_review;
 
+import com.moyoy.domain.pr_review.dto.PrReviewHitCreate;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,7 +17,24 @@ public class PrReviewHit {
 
     private static final Duration TTL = Duration.ofHours(1);
 
+    public static PrReviewHit create(PrReviewHitCreate dto) {
+        return new PrReviewHit(
+            null,
+            dto.prReviewId(),
+            dto.userId(),
+            dto.lastIncreasedAt()
+        );
+    }
+
+    public void updateLastTime(LocalDateTime now) {
+        this.lastIncreasedAt = now;
+    }
+
     public boolean canIncrease(LocalDateTime now) {
+        if (lastIncreasedAt.equals(now)) {
+            return true;
+        }
+
         return lastIncreasedAt.plus(TTL).isBefore(now);
     }
 }

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHit.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHit.java
@@ -26,10 +26,6 @@ public class PrReviewHit {
 			dto.lastIncreasedAt());
 	}
 
-	public void updateLastTime(LocalDateTime now) {
-		this.lastIncreasedAt = now;
-	}
-
 	public boolean canIncrease(LocalDateTime now) {
 		if (lastIncreasedAt.equals(now)) {
 			return true;

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHit.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHit.java
@@ -1,40 +1,40 @@
 package com.moyoy.domain.pr_review;
 
-import com.moyoy.domain.pr_review.dto.PrReviewHitCreate;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
+import com.moyoy.domain.pr_review.dto.PrReviewHitCreate;
 
 @Getter
 @Builder
 public class PrReviewHit {
-    private Long id;
-    private Long prReviewId;
-    private Long userId;
-    private LocalDateTime lastIncreasedAt;
+	private Long id;
+	private Long prReviewId;
+	private Long userId;
+	private LocalDateTime lastIncreasedAt;
 
-    private static final Duration TTL = Duration.ofHours(1);
+	private static final Duration TTL = Duration.ofHours(1);
 
-    public static PrReviewHit create(PrReviewHitCreate dto) {
-        return new PrReviewHit(
-            null,
-            dto.prReviewId(),
-            dto.userId(),
-            dto.lastIncreasedAt()
-        );
-    }
+	public static PrReviewHit create(PrReviewHitCreate dto) {
+		return new PrReviewHit(
+			null,
+			dto.prReviewId(),
+			dto.userId(),
+			dto.lastIncreasedAt());
+	}
 
-    public void updateLastTime(LocalDateTime now) {
-        this.lastIncreasedAt = now;
-    }
+	public void updateLastTime(LocalDateTime now) {
+		this.lastIncreasedAt = now;
+	}
 
-    public boolean canIncrease(LocalDateTime now) {
-        if (lastIncreasedAt.equals(now)) {
-            return true;
-        }
+	public boolean canIncrease(LocalDateTime now) {
+		if (lastIncreasedAt.equals(now)) {
+			return true;
+		}
 
-        return lastIncreasedAt.plus(TTL).isBefore(now);
-    }
+		return lastIncreasedAt.plus(TTL).isBefore(now);
+	}
 }

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHitRepository.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHitRepository.java
@@ -3,7 +3,7 @@ package com.moyoy.domain.pr_review;
 import java.time.LocalDateTime;
 
 public interface PrReviewHitRepository {
-    PrReviewHit saveIfNotExist(PrReviewHit prReviewHit);
+	PrReviewHit saveIfNotExist(PrReviewHit prReviewHit);
 
-    void updateLastIncreasedAt(Long id, LocalDateTime now);
+	void updateLastIncreasedAt(Long id, LocalDateTime now);
 }

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHitRepository.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHitRepository.java
@@ -1,0 +1,9 @@
+package com.moyoy.domain.pr_review;
+
+import java.time.LocalDateTime;
+
+public interface PrReviewHitRepository {
+    PrReviewHit saveIfNotExist(PrReviewHit prReviewHit);
+
+    void updateLastIncreasedAt(Long id, LocalDateTime now);
+}

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHitRepository.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewHitRepository.java
@@ -3,7 +3,7 @@ package com.moyoy.domain.pr_review;
 import java.time.LocalDateTime;
 
 public interface PrReviewHitRepository {
-	PrReviewHit saveIfNotExist(PrReviewHit prReviewHit);
+	PrReviewHit findOrCreate(PrReviewHit prReviewHit);
 
 	void updateLastIncreasedAt(Long id, LocalDateTime now);
 }

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewRepository.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReviewRepository.java
@@ -8,5 +8,7 @@ public interface PrReviewRepository {
 
 	Optional<PrReview> findById(Long reviewId);
 
+	void increaseHitCount(Long reviewId);
+
 	void deleteById(Long reviewId);
 }

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/dto/PrReviewHitCreate.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/dto/PrReviewHitCreate.java
@@ -1,0 +1,10 @@
+package com.moyoy.domain.pr_review.dto;
+
+import java.time.LocalDateTime;
+
+public record PrReviewHitCreate(
+    Long prReviewId,
+    Long userId,
+    LocalDateTime lastIncreasedAt
+) {
+}

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/dto/PrReviewHitCreate.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/dto/PrReviewHitCreate.java
@@ -3,8 +3,7 @@ package com.moyoy.domain.pr_review.dto;
 import java.time.LocalDateTime;
 
 public record PrReviewHitCreate(
-    Long prReviewId,
-    Long userId,
-    LocalDateTime lastIncreasedAt
-) {
+	Long prReviewId,
+	Long userId,
+	LocalDateTime lastIncreasedAt) {
 }

--- a/Moyoy-Domain/src/test/java/com/moyoy/domain/pr_review/PrReviewHitTest.java
+++ b/Moyoy-Domain/src/test/java/com/moyoy/domain/pr_review/PrReviewHitTest.java
@@ -1,0 +1,48 @@
+package com.moyoy.domain.pr_review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.moyoy.domain.pr_review.dto.PrReviewHitCreate;
+
+class PrReviewHitTest {
+
+	@Test
+	@DisplayName("lastIncreasedAt이 now면 조회수 증가할 수 있다.")
+	void canIncrease_sameTime() {
+		LocalDateTime now = LocalDateTime.now();
+
+		PrReviewHit hit = PrReviewHit.create(
+			new PrReviewHitCreate(1L, 10L, now));
+
+		assertThat(hit.canIncrease(now)).isTrue();
+	}
+
+	@Test
+	@DisplayName("TTL 1시간 이내이면 중복 증가로 판단한다.")
+	void canIncrease_withinTTL() {
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime last = now.minusMinutes(30);
+
+		PrReviewHit hit = PrReviewHit.create(
+			new PrReviewHitCreate(1L, 10L, last));
+
+		assertThat(hit.canIncrease(now)).isFalse();
+	}
+
+	@Test
+	@DisplayName("TTL 1시간 범위를 초과했다면 증가 가능하다.")
+	void canIncrease_afterTTL() {
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime last = now.minusHours(1).minusSeconds(1);
+
+		PrReviewHit hit = PrReviewHit.create(
+			new PrReviewHitCreate(1L, 10L, last));
+
+		assertThat(hit.canIncrease(now)).isTrue();
+	}
+}

--- a/Moyoy-Domain/src/test/java/com/moyoy/domain/pr_review/PrReviewTest.java
+++ b/Moyoy-Domain/src/test/java/com/moyoy/domain/pr_review/PrReviewTest.java
@@ -1,12 +1,12 @@
 package com.moyoy.domain.pr_review;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 class PrReviewTest {
 

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitEntity.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitEntity.java
@@ -2,10 +2,7 @@ package com.moyoy.infra.database.mysql.pr_review;
 
 import com.moyoy.infra.database.mysql.support.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -20,7 +17,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PrReviewHitEntity extends BaseTimeEntity {
 
     @Id

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitEntity.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitEntity.java
@@ -1,0 +1,39 @@
+package com.moyoy.infra.database.mysql.pr_review;
+
+import com.moyoy.infra.database.mysql.support.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "pr_review_hits",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_user_review_hit",
+        columnNames = {"user_id", "pr_review_id"}
+    )
+)
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PrReviewHitEntity extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "pr_review_hit_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long prReviewId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private LocalDateTime lastIncreasedAt;
+}

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitEntity.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitEntity.java
@@ -17,7 +17,7 @@ import jakarta.persistence.*;
 public class PrReviewHitEntity extends BaseTimeEntity {
 
 	@Id
-	@Column(name = "pr_review_hit_id")
+	@Column(name = "hit_id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitEntity.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitEntity.java
@@ -1,36 +1,32 @@
 package com.moyoy.infra.database.mysql.pr_review;
 
-import com.moyoy.infra.database.mysql.support.entity.BaseTimeEntity;
-import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.LocalDateTime;
 
+import lombok.*;
+
+import com.moyoy.infra.database.mysql.support.entity.BaseTimeEntity;
+
+import jakarta.persistence.*;
+
 @Entity
-@Table(
-    name = "pr_review_hits",
-    uniqueConstraints = @UniqueConstraint(
-        name = "uq_user_review_hit",
-        columnNames = {"user_id", "pr_review_id"}
-    )
-)
+@Table(name = "pr_review_hits", uniqueConstraints = @UniqueConstraint(name = "uq_user_review_hit", columnNames = {"user_id", "pr_review_id"}))
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PrReviewHitEntity extends BaseTimeEntity {
 
-    @Id
-    @Column(name = "pr_review_hit_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@Column(name = "pr_review_hit_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(nullable = false)
-    private Long prReviewId;
+	@Column(nullable = false)
+	private Long prReviewId;
 
-    @Column(nullable = false)
-    private Long userId;
+	@Column(nullable = false)
+	private Long userId;
 
-    @Column(nullable = false)
-    private LocalDateTime lastIncreasedAt;
+	@Column(nullable = false)
+	private LocalDateTime lastIncreasedAt;
 }

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitJpaRepository.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitJpaRepository.java
@@ -1,0 +1,5 @@
+package com.moyoy.infra.database.mysql.pr_review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PrReviewHitJpaRepository extends JpaRepository<PrReviewHitEntity, Long> {}

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitJpaRepository.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitJpaRepository.java
@@ -1,5 +1,17 @@
 package com.moyoy.infra.database.mysql.pr_review;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDateTime;
 
-public interface PrReviewHitJpaRepository extends JpaRepository<PrReviewHitEntity, Long> {}
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PrReviewHitJpaRepository extends JpaRepository<PrReviewHitEntity, Long> {
+
+	PrReviewHitEntity findByPrReviewIdAndUserId(Long prReviewId, Long userId);
+
+	@Modifying
+	@Query("UPDATE PrReviewHitEntity h SET h.lastIncreasedAt = :now WHERE h.id = :id")
+	void updateLastIncreasedAt(@Param("id") Long id, @Param("now") LocalDateTime now);
+}

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitMapper.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitMapper.java
@@ -1,0 +1,24 @@
+package com.moyoy.infra.database.mysql.pr_review;
+
+import com.moyoy.domain.pr_review.PrReviewHit;
+
+public class PrReviewHitMapper {
+
+    public static PrReviewHit toModel(PrReviewHitEntity entity) {
+        return PrReviewHit.builder()
+            .id(entity.getId())
+            .prReviewId(entity.getPrReviewId())
+            .userId(entity.getUserId())
+            .lastIncreasedAt(entity.getLastIncreasedAt())
+            .build();
+    }
+
+    public static PrReviewHitEntity toEntity(PrReviewHit model) {
+        return PrReviewHitEntity.builder()
+            .id(model.getId())
+            .prReviewId(model.getPrReviewId())
+            .userId(model.getUserId())
+            .lastIncreasedAt(model.getLastIncreasedAt())
+            .build();
+    }
+}

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitMapper.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitMapper.java
@@ -12,13 +12,4 @@ public class PrReviewHitMapper {
 			.lastIncreasedAt(entity.getLastIncreasedAt())
 			.build();
 	}
-
-	public static PrReviewHitEntity toEntity(PrReviewHit model) {
-		return PrReviewHitEntity.builder()
-			.id(model.getId())
-			.prReviewId(model.getPrReviewId())
-			.userId(model.getUserId())
-			.lastIncreasedAt(model.getLastIncreasedAt())
-			.build();
-	}
 }

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitMapper.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitMapper.java
@@ -4,21 +4,21 @@ import com.moyoy.domain.pr_review.PrReviewHit;
 
 public class PrReviewHitMapper {
 
-    public static PrReviewHit toModel(PrReviewHitEntity entity) {
-        return PrReviewHit.builder()
-            .id(entity.getId())
-            .prReviewId(entity.getPrReviewId())
-            .userId(entity.getUserId())
-            .lastIncreasedAt(entity.getLastIncreasedAt())
-            .build();
-    }
+	public static PrReviewHit toModel(PrReviewHitEntity entity) {
+		return PrReviewHit.builder()
+			.id(entity.getId())
+			.prReviewId(entity.getPrReviewId())
+			.userId(entity.getUserId())
+			.lastIncreasedAt(entity.getLastIncreasedAt())
+			.build();
+	}
 
-    public static PrReviewHitEntity toEntity(PrReviewHit model) {
-        return PrReviewHitEntity.builder()
-            .id(model.getId())
-            .prReviewId(model.getPrReviewId())
-            .userId(model.getUserId())
-            .lastIncreasedAt(model.getLastIncreasedAt())
-            .build();
-    }
+	public static PrReviewHitEntity toEntity(PrReviewHit model) {
+		return PrReviewHitEntity.builder()
+			.id(model.getId())
+			.prReviewId(model.getPrReviewId())
+			.userId(model.getUserId())
+			.lastIncreasedAt(model.getLastIncreasedAt())
+			.build();
+	}
 }

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitRepositoryImpl.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewHitRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.moyoy.infra.database.mysql.pr_review;
+
+import java.time.LocalDateTime;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.moyoy.domain.pr_review.PrReviewHit;
+import com.moyoy.domain.pr_review.PrReviewHitRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class PrReviewHitRepositoryImpl implements PrReviewHitRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+	private final PrReviewHitJpaRepository prReviewHitJpaRepository;
+
+	@Override
+	public PrReviewHit findOrCreate(PrReviewHit hit) {
+
+		String sql = """
+			INSERT IGNORE INTO pr_review_hits (pr_review_id, user_id, last_increased_at)
+			VALUES (?, ?, ?)
+			""";
+
+		jdbcTemplate.update(sql,
+			hit.getPrReviewId(),
+			hit.getUserId(),
+			hit.getLastIncreasedAt());
+
+		PrReviewHitEntity entity = prReviewHitJpaRepository
+			.findByPrReviewIdAndUserId(hit.getPrReviewId(), hit.getUserId());
+
+		return PrReviewHitMapper.toModel(entity);
+	}
+
+	@Override
+	public void updateLastIncreasedAt(Long id, LocalDateTime now) {
+		prReviewHitJpaRepository.updateLastIncreasedAt(id, now);
+	}
+}

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewJpaRepository.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewJpaRepository.java
@@ -1,5 +1,13 @@
 package com.moyoy.infra.database.mysql.pr_review;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface PrReviewJpaRepository extends JpaRepository<PrReviewEntity, Long> {}
+public interface PrReviewJpaRepository extends JpaRepository<PrReviewEntity, Long> {
+
+	@Modifying
+	@Query("UPDATE PrReviewEntity r SET r.hitCount = r.hitCount + 1 WHERE r.id = :reviewId")
+	void increaseHitCount(@Param("reviewId") Long reviewId);
+}

--- a/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewRepositoryImpl.java
+++ b/Moyoy-Infra/src/main/java/com/moyoy/infra/database/mysql/pr_review/PrReviewRepositoryImpl.java
@@ -31,6 +31,11 @@ public class PrReviewRepositoryImpl implements PrReviewRepository {
 	}
 
 	@Override
+	public void increaseHitCount(Long reviewId) {
+		prReviewJpaRepository.increaseHitCount(reviewId);
+	}
+
+	@Override
 	public void deleteById(Long reviewId) {
 		prReviewJpaRepository.deleteById(reviewId);
 	}


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #91 

## ☑️ 완료 태스크
- [x] 조회 기록 및 중복 방지 목적 브릿지 테이블 엔티티 생성
- [x] `PR 리뷰 요청글 상세 조회` API에 조회수 증가 로직 추가
- [x] 조회수 중복 증가 방지
- [x] 조회수 증가 작업에서 동시성 문제 해결
- [x] 요청글 내용 조회 작업과 조회수 증가 작업 비동기로 분리
- [x] 도메인 모델 유닛 테스트 추가

<br />

## 🔎 PR 내용
조회수 관리는 고려할 부분이 많아서 8월부터 계속 고민을 하고 있었는데요.
이제야 최적의 방식을 찾은 것 같습니다 (지금 뇌 수준에서는)
최적의 방식을 바로 구현하는 것보단 단계별로(v1~v4) 구현하면서 지표로 비교하는 게 좋겠다 판단했습니다.

`요청글 조회 API`는 조회(Query)와 조회수 증가(Command) 결합되어 있고,
중복 방지, 동시성, DB 부하, 분산 환경까지 같이 고려해야 하기에 좀 까다로웠습니다.

그래서 아래 조건들을 만족하면서 점점 개선해나가는 방식으로 차례로 구현해보겠습니다.
<br />

```Rust
1. 조회수 중복 증가 방지
  -> 로그인 사용자/익명 사용자를 식별하고 일정 기간 내 중복 증가를 막아야 함

2. 조회수 중복 증가 방지를 위한 데이터 저장소 선택 (RDB vs Redis )
  -> 각 선택지마다 비용/부하/운영 난이도 비교

3. 중복 증가 기간에 대한 판단 방법
  -> TTL 방식 vs 마지막 증가 시각 비교

4. 요청글 조회 API마다 UPDATE 쿼리가 나가는 데에 대한 DB 부하 완화

5. 동시성 문제 없는 조회수 증가 처리

6. aws 프리티어 인프라 환경 내에서 감당 가능할 것 

7. 분산 서버 환경이라 개별 서버 메모리를 활용하는 건 피할 것
```
<br />


## 1️⃣ v1: `회원`-`요청글` 브릿지 테이블 기반 조회수 기록
v1은 가장 단순한 방식으로, 회원-요청글 브릿지 테이블(pr_review_hits)에 기록해 중복 증가를 막는 겁니다.

<img width="800" alt="Image" src="https://github.com/user-attachments/assets/cd1ccd45-8f47-4944-b7ed-e70f9c438cd9" />

아주 단순한 구조라 문제도 많긴 하지만 우선 장단점을 생각해보죠.
<br />

#### 장점
- 구현이 매우 단순하다는 점
- 중복 조회 방지를 RDB만으로 커버 가능하다는 것
- 조회 기록이 데이터로 남아서 향후 분석 등에 이용해볼 수도 있다는 점 (지금 상황에 크게 와닿진 않음)

#### 단점
- 게시글을 조회할 때마다 `SELECT -> INSERT/UPDATE`가 발생해 DB에 부하가 커짐
- 트패픽이 늘어날 수록 테이블이 급격히 커짐
- 사실 단순히 조회수 증가 기능인데 기록 방식이 무거움 (중요도를 따졌을 때 조회수가 그 정도는 아님)
<br />

### 중복 판단 방식 (v1에서 선택)
브릿지 테이블을 두는 방식에서도 중복 판단은 여러 방법이 있죠.
```Rust
1. [삭제] 중복 증가로 볼 기간동안 데이터를 저장하고, 해당 시각 이후 테이블 내 데이터 삭제
  -> TTL 느낌인데, MySQL에서 TTL을 지원하진 않기에 배치 작업으로 삭제 처리 필요

2. [보존] 마지막 조회수 증가 시각 컬럼을 추가해, 증가 여부를 판단 ✅
```

👉 마지막 증가 시각(last_increased_at)을 저장하고, 현재와 비교해서 TTL(1시간) 내 중복 증가를 막는 2번을 선택했습니다.
<br />

### v1 최종 ERD
<img width="800" alt="image" src="https://github.com/user-attachments/assets/bf55c4bb-c4c3-4a3f-a3a8-5ddf0f470758" />

이렇게 조회수 테이블을 두고는 있지만 중복 증가 방지 목적이 큽니다.
특히 "요청글별 조회수 수치"는 조회/정렬에서 자주 사용되고 있기 때문에,
브릿지 테이블에 매번 COUNT를 하지 않고 요청글 엔티티에 hitCount를 비정규화해서 구현했습니다.
<br />

### 2줄 요약
👉 `마지막 조회수 증가 시각`을 가진 조회수 브릿지 테이블로 중복 증가를 방지하고,
요청글의 hitCount는 별도 컬럼으로 비정규화해서 증가 처리하는 방식으로 v1을 구현했다.
<br />

넘어가기 전에 동시성 문제 처리와 조회/조회수 증가 비동기 분리 작업 설명하고 갈게요.
<br />

## 🛠️ 조회수 증가 시각 기록 시 동시성 문제 해결 `INSERT IGNORE INTO`
<img width="800" alt="image" src="https://github.com/user-attachments/assets/f3c02bbf-e47a-480e-861c-4ef51a315735" />

조회수 중복 증가 방지를 위해 (pr_review_id, user_id) 조합으로 복합 유니크 제약 조건을 뒀습니다.

하지만 단순히 SELECT → 없으면 INSERT 같은 흐름으로 구현할 경우엔 동시성 문제가 발생할 수 있습니다.
1. 사용자가 새로고침을 빠르게 연타하거나
2. 여러 장치나 탭에서 동일한 요청 글을 동시에 조회하는 경우가 있을 수 있죠.

두 요청이 거의 동시에 기록이 없다고 판단해 INSERT를 시도하면
중복 row를 만드려고 하거나 DuplicateKeyException가 터지게 될 겁니다.
<br />

특히 이 문제는 아직 테이블에 존재하지 않는 row에 대한 경쟁이라
`SELECT … FOR UPDATE`같은 Exclusive lock을 선점하는 것도 불가능합니다.
(존재하지 않는 row라서 잠글 대상 자체가 없기 때문이죠 💁‍♂️)
<br />

그래서 이 문제를 애플리케이션 레벨에서 재시도하거나 lock으로 해결하기보다는
앞에서 만든 (pr_review_id, user_id) UNIQUE 인덱스를 활용했습니다.

```SQL
INSERT IGNORE INTO pr_review_hits (pr_review_id, user_id, last_increased_at)
VALUES (?, ?, ?)
```

`INSERT IGNORE INTO`로 아직 row가 없는 첫 조회 요청이라면 INSERT가 정상적으로 수행하고,
동시에 들어오거나 이미 row가 존재하면 UNIQUE 충돌이 발생하긴 해도 에러 없이 무시합니다.
동시에 들어온 요청이니 `lastIncreasedAt`의 시간도 의미 상 크게 문제되지 않죠.

즉, 동시에 여러 INSERT 요청이 들어와도 DB 차원에서 하나의 row만 생성한다는 걸 보장하니까,
애플리케이션 레벨에서 race condition을 처리해야 할 필요가 없게 된 겁니다.
<br />

## 🛠️ 요청글 내용 조회와 조회수 증가 작업을 비동기로 분리 `@Async`
`요청글 조회 API`는 조회(Query)와 조회수 증가(Command) 두 가지 성격의 작업이 섞여있습니다.

이 두 작업을 한 트랜잭션이나 동기로 묶어버리면,
1. 조회 API의 응답 시간이 DB write 작업 때문에 불필요하게 길어지게 되고,
2. 트래픽이 늘어날수록 조회 API가 쓰기 병목까지 떠안게 됩니다.

조회수 처리 로직때문에 조회 API의 성능에 직접적인 영향을 주게 되는 거죠.

### 해결 방법: 조회수 증가 작업은 비동기 분리

실시간성이 중요하긴 하지 조회수 증가는 응답 결과에 즉시 반영될 필요는 없기 때문에,
상세 조회 로직과 분리하고 `@Async`를 활용해 조회수 증가를 비동기로 처리하도록 구현했습니다.

```Java
// --------------------------
// PrReviewService
// --------------------------
public PrReviewDetailResult getPrReviewDetail(Long reviewId, Long userId) {

	PrReviewDetailData data = prReviewQueryRepository.findById(reviewId)
		.orElseThrow(PrReviewNotFoundException::new);

	boolean isWriter = data.userId().equals(userId);

	prReviewAsyncService.increaseHitAsync(reviewId, userId);

	return PrReviewDetailResult.from(data, isWriter);
}

// --------------------------
// PrReviewAsyncService
// --------------------------
@Service
@RequiredArgsConstructor
public class PrReviewAsyncService {

	private final PrReviewRepository prReviewRepository;
	private final PrReviewHitRepository prReviewHitRepository;

	@Async("hitsExecutor")
	@Transactional
	public void increaseHitAsync(Long reviewId, Long userId) {

		LocalDateTime now = LocalDateTime.now();

		PrReviewHit hit = prReviewHitRepository.findOrCreate(
			PrReviewHit.create(new PrReviewHitCreate(reviewId, userId, now)));

		if (!hit.canIncrease(now))
			return;

		prReviewRepository.increaseHitCount(reviewId);

		prReviewHitRepository.updateLastIncreasedAt(hit.getId(), now);
	}
}
```

코드를 보면 AsyncService를 따로 만든 것을 확인할 수 있는데요.

처음에는 같은 Service 내부에 @Async 메서드를 정의했지만,
Spring의 `@Async`는 프록시 기반으로 동작한다는 걸 알게됐습니다.

동일 클래스 내부 호출은 프록시를 거치지 않아서 비동기가 아니라 동기 호출로 실행되는 거죠.

그래서 내부 호출 대신 self-reference 방식으로 해야 하나 했었는데,
순환 참조가 일어나는 구조를 만들기보다는 AsyncSerivce로 따로 클래스를 빼는 구조로 구성했습니다.
<br />

<br />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/772d3303-0580-4dd6-b9c2-08ba57994ea0" />

사실 CQRS 얘기해놓고 `findOrCreate()`가 Query/Command 역할을 동시에 수행하는 점에서
엄밀하게 따지면 CQRS 규칙은 어긴 구조입니다.

다만 존재하지 않는 row에 락을 걸 수 없는 상황이었기 때문에,
DB 차원의 유니크 제약으로 동시성 문제를 해결하기 위해 실용적으로 접근하기로 했습니다.
<br />

### 작업 요약
1. hit row 중복 생성 문제 DB 유니크 제약 + `INSERT IGNORE INTO`로 해결
2. TTL 내 중복 조회수 증가는 시간 값을 비교해 판단
3. 조회 API의 성능에 영향을 주지 않게 비동기 처리

## 🪄 앞으로의 리팩토링 계획
아래는 앞으로 개선해 나갈 작업 계획들입니다.
<br />

### 2️⃣ v2: Redis에 조회를 SET으로 기록해 중복 증가 방지
요청글별로 Redis SET(pr_review_id, user_id)에 유저를 기록해 중복 조회를 판단하는 겁니다.

#### 장점
1. DB 조회/INSERT 제거 → DB 부하 대폭 감소
2. Redis SET 자체가 중복을 허용하지 않고, 단일 스레드라 동시성 문제 해결
3. TTL 설정으로 중복 증가 기간 관리 간단

#### 단점
1. 조회 기록이 Redis 메모리를 점유
2. 조회수 누적 값은 여전히 매번 RDB UPDATE 필요
3. Redis 다운되거나 OOM 발생했을 때의 후처리, 대처
<br />

### 3️⃣ v3: Redis에 조회 SET에 기록 중복 증가 방지 + 누적 조회수 저장/배치로 일괄 UPDATE
그대로 중복 증가 판단을 Redis SET으로 하는 것까진 v2랑 같은데,
조회수 누적을 Redis에서 하다가 일정 주기로 RDB에 배치로 일괄 반영하는 아이디어입니다.

배치로 일괄 UPDATE 하는 만큼, 여기서는 TTL 기준을 고정 시간 단위(ex. 1시간)로 잡아야 합니다.

#### 장점
1. 조회 API에서 RDB 쓰기 완전히 제거
2. TTL 동안 쌓인 RDB에 배치로 일괄 UPDATE 처리 → 부하 예측 가능
3. Redis 장애 시에도 RDB는 최종 정합성 유지

#### 단점
1. Redis, 배치 작업 관리 필요
2. Redis랑 RDB 간에 정합성 맞추는 방법을 고려해야 함
3. Redis 다운되거나 OOM 발생했을 때의 후처리, 대처
<br />

### 4️⃣ v4: Redis hyperloglog 중복 증가 방지 + 누적 조회수 저장/배치로 일괄 UPDATE
v3에서 중복 증가 기록을 위해 쓰던 SET 대신 HyperLogLog로 근사 집계하는 아이디어입니다.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/2a9edf9c-bc2b-4aae-a1be-ffdfb5bc75bf" />

hyperloglog.. 이걸 알고 나니 그동안의 모든 근심과 스트레스, 걱정이 없어지고 건강해졌습니다 👍
이런 게 있었다니, 살~짝 눈물 흘릴 뻔 했습니다.

#### 장점
1. 조회 기록당 메모리 사용량 대폭 절약 (≈ 12KB 고정)
2. 트래픽·유저 수 증가에 거의 영향 없음
  -> 고트래픽 환경에서도 안정적인 조회수 처리
3. DB 부하 최소화 + 분산 환경 친화적

#### 단점
1. hyperloglog는 추정 집계라 약 0.81% 오차가 존재함 (대략 1000개에 8개 꼴)
  -> 우리 서비스의 PR리뷰요청글 조회수에 이 정도 오차는 충분히 감수할 만함!
2. Redis 다운되거나 OOM 발생했을 때의 후처리, 대처
<br />

## 📷 성능 스크린샷
성능 측정은 알아보고 있는데 어떻게 하는지 조사하고 결과 후첨할게요.
```Rust
1. pr_review UPDATE QPS (초당 UPDATE 횟수)
4. pr_review_hits INSERT QPS
5. DB CPU 사용률
등등..
```
