### PR TITLE
Refactor: 마감된 요청글은 수정할 수 없도록 검증 추가

### DIFF
--- a/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
+++ b/Moyoy-Api/src/main/java/com/moyoy/api/pr_review/application/PrReviewService.java
@@ -12,7 +12,6 @@ import com.moyoy.api.pr_review.application.request.SearchConditionData;
 import com.moyoy.api.pr_review.application.response.*;
 
 import com.moyoy.domain.pr_review.PrReview;
-import com.moyoy.domain.pr_review.PrReviewHitRepository;
 import com.moyoy.domain.pr_review.PrReviewRepository;
 import com.moyoy.domain.pr_review.error.PrReviewDeleteForbiddenException;
 import com.moyoy.domain.pr_review.error.PrReviewEditForbiddenException;
@@ -68,11 +67,7 @@ public class PrReviewService {
 		PrReview prReview = prReviewRepository.findById(reviewId)
 			.orElseThrow(PrReviewNotFoundException::new);
 
-		if (!prReview.getUserId().equals(userId)) {
-			throw new PrReviewEditForbiddenException();
-		}
-
-		prReview.updateDetail(data.toCommand());
+		prReview.updateDetail(userId, data.toCommand());
 
 		Long updatedReviewId = prReviewRepository.save(prReview).getId();
 

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReview.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/PrReview.java
@@ -1,5 +1,7 @@
 package com.moyoy.domain.pr_review;
 
+import com.moyoy.domain.pr_review.error.PrReviewEditConflictException;
+import com.moyoy.domain.pr_review.error.PrReviewEditForbiddenException;
 import java.time.LocalDateTime;
 
 import lombok.Builder;
@@ -38,12 +40,25 @@ public class PrReview {
 			prReviewCreate.closedAt());
 	}
 
-	public void updateDetail(PrReviewUpdate content) {
+	public void updateDetail(Long userId, PrReviewUpdate content) {
+
+		validateUpdateAvailable(userId);
+
 		this.title = content.title();
 		this.position = content.position();
 		this.prUrl = content.prUrl();
 		this.content = content.content();
 		this.closedAt = content.closedAt();
+	}
+
+	private void validateUpdateAvailable(Long userId) {
+		if (!this.userId.equals(userId)) {
+			throw new PrReviewEditForbiddenException();
+		}
+
+		if (status.isClosed()) {
+			throw new PrReviewEditConflictException();
+		}
 	}
 
 	public void close(LocalDateTime eventTime) {

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/error/PrReviewEditConflictException.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/error/PrReviewEditConflictException.java
@@ -1,0 +1,11 @@
+package com.moyoy.domain.pr_review.error;
+
+import static com.moyoy.domain.pr_review.error.PrReviewErrorCode.*;
+
+import com.moyoy.common.error.MoyoException;
+
+public class PrReviewEditConflictException extends MoyoException {
+    public PrReviewEditConflictException() {
+        super(PR_REVIEW_EDIT_CONFLICT);
+    }
+}

--- a/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/error/PrReviewErrorCode.java
+++ b/Moyoy-Domain/src/main/java/com/moyoy/domain/pr_review/error/PrReviewErrorCode.java
@@ -25,7 +25,8 @@ public enum PrReviewErrorCode implements BaseErrorCode {
 	PR_REVIEW_NOT_FOUND(NOT_FOUND, "PR_REVIEW_404_1", "존재하지 않는 PR 리뷰 요청글입니다."),
 
 	// 409: 상태 충돌
-	PR_REVIEW_DELETE_CONFLICT(CONFLICT, "PR_REVIEW_409_1", "종료된 PR 리뷰 요청글은 삭제할 수 없습니다.");
+	PR_REVIEW_EDIT_CONFLICT(CONFLICT, "PR_REVIEW_409_1", "종료된 PR 리뷰 요청글은 수정할 수 없습니다."),
+	PR_REVIEW_DELETE_CONFLICT(CONFLICT, "PR_REVIEW_409_2", "종료된 PR 리뷰 요청글은 삭제할 수 없습니다.");
 
 	private final Integer status;
 	private final String code;


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #issue_number

## ☑️ 완료 태스크
- [x] 검증 책임 `PrReview` 객체가 갖도록 수정
- [x] PR 리뷰 요청글 상태가 CLOSED일 시, 수정 불가능 예외 처리

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->
기존에 수정 검증 로직을 Service에서 전개하고 있었는데 이를 객체가 처리하도록 옮겼고,
PR 리뷰 요청글 `CLOSED` 상태일 때 수정이 불가능 하도록 검증 추가했습니다.
<br />

## 📷 스크린샷

<!-- 팀원들이 이해할 수 있게 구현한 화면을 보여주세요 -->